### PR TITLE
add config for maven-compiler-plugin and maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,4 +112,39 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.2</version>
+          <configuration>
+            <source>${maven.compile.source}</source>
+            <target>${maven.compile.target}</target>
+            <encoding>${project.build.sourceEncoding}</encoding>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+              <manifestEntries>
+                <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
+                <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
+                <build-time>${maven.build.timestamp}</build-time>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
*maven-compiler-plugin*
At least on my computer, the "m2e"-plugin for Eclipse needs this config to set the right Java-Source-Version.

*maven-jar-plugin*
The config generates a complete "META-INF/MANIFEST.MF" with some informations from the pom.xml like the Version.
This information can be read at Runtime with e.g.: org.xmlunit.diff.Comparison.class.getPackage().getImplementationVersion();
(The Apache Commons libraries like "commons-lang3.jar" uses the same config)