### PR TITLE
implement CompareMatcher

### DIFF
--- a/xmlunit-matchers/pom.xml
+++ b/xmlunit-matchers/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/CompareMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/CompareMatcher.java
@@ -1,0 +1,313 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package org.xmlunit.matchers;
+
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonControllers;
+import org.xmlunit.diff.ComparisonFormatter;
+import org.xmlunit.diff.ComparisonListener;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.DefaultComparisonFormatter;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluator;
+import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.diff.ElementSelector;
+import org.xmlunit.diff.NodeMatcher;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import java.lang.reflect.Constructor;
+import java.util.logging.Logger;
+
+
+/**
+ * This Hamcrest {@link Matcher} compares two XML sources with each others.
+ * <p>
+ * The Test-Object and Control-Object can be all types of input supported by {@link Input#from(Object)}.
+ * <p>
+ * <b>Simple Example</b><br>
+ * This example will throw an AssertionError: "Expected attribute value 'abc' but was 'xyz'".
+ * 
+ * <pre>
+ * final String control = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ * final String test = &quot;&lt;a&gt;&lt;b attr=\&quot;xyz\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ * 
+ * assertThat(test, CompareMatcher.isIdenticalTo(control));
+ * </pre>
+ * <p>
+ * <b>Complex Example</b><br>
+ * In most cases you will have a static factory method for your project which wraps all project-specific configurations
+ * like customized {@link ElementSelector} or {@link DifferenceEvaluator}.
+ * 
+ * <pre>
+ * 
+ * public static CompareMatcher isMyProjSimilarTo(final File file) {
+ *     return CompareMatcher.isSimilarTo(file)
+ *         .throwComparisonFailure()
+ *         .normalizeWhitespace()
+ *         .ignoreComments()
+ *         .withNodeMatcher(new DefaultNodeMatcher(new MyElementSelector()))
+ *         .withDifferenceEvaluator(DifferenceEvaluators.chain(
+ *             DifferenceEvaluators.Default, new MyDifferenceEvaluator()));
+ * }
+ * </pre>
+ * 
+ * And then somewhere in your Tests:
+ * 
+ * <pre>
+ * assertThat(test, isMyProjSimilarTo(controlFile));
+ * </pre>
+ */
+public final class CompareMatcher extends BaseMatcher<Object> {
+
+    private static final Logger LOGGER = Logger.getLogger(CompareMatcher.class.getName());
+
+    private final DiffBuilder diffBuilder;
+
+    private boolean throwComparisonFailure;
+    
+    private ComparisonResult checkFor;
+
+    private Diff diffResult;
+
+    private boolean formatXml;
+
+    private static final ComparisonFormatter DEFAULT_FORMATTER = new DefaultComparisonFormatter();
+
+    private ComparisonFormatter comparisonFormatter = DEFAULT_FORMATTER;
+
+    private static Constructor<?> comparisonFailureConstructor;
+
+    private CompareMatcher(Object control) {
+        super();
+        diffBuilder = DiffBuilder.compare(control);
+    }
+
+    /**
+     * Create a {@link CompareMatcher} which compares the test-Object with the given control Object for identical.
+     * <p>
+     * As input all types are supported which are supported by {@link Input#from(Object)}.
+     */
+    public static CompareMatcher isIdenticalTo(final Object control) {
+        return new CompareMatcher(control).checkForIdentical();
+    }
+
+    /**
+     * Create a {@link CompareMatcher} which compares the test-Object with the given control Object for similar.
+     * <p>
+     * Example for Similar: The XML node "&lt;a&gt;Text&lt;/a&gt;" and "&lt;a&gt;&lt;![CDATA[Text]]&gt;&lt;/a&gt;" are
+     * similar and the Test will not fail.
+     * <p>
+     * The rating, if a node is similar, will be done by the {@link DifferenceEvaluators#Default}.
+     * See {@link DiffBuilder#withDifferenceEvaluator(DifferenceEvaluator)}
+     * <p>
+     * As input all types are supported which are supported by {@link Input#from(Object)}.
+     */
+    public static CompareMatcher isSimilarTo(final Object control) {
+        return new CompareMatcher(control).checkForSimilar();
+    }
+
+    private CompareMatcher checkForSimilar() {
+        diffBuilder.checkForSimilar();
+        checkFor = ComparisonResult.SIMILAR;
+        return this;
+    }
+
+    private CompareMatcher checkForIdentical() {
+        diffBuilder.checkForIdentical();
+        checkFor = ComparisonResult.EQUAL;
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#ignoreWhitespace()
+     */
+    public CompareMatcher ignoreWhitespace() {
+        formatXml = true;
+        diffBuilder.ignoreWhitespace();
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#normalizeWhitespace()
+     */
+    public CompareMatcher normalizeWhitespace() {
+        formatXml = true;
+        diffBuilder.normalizeWhitespace();
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#ignoreComments()
+     */
+    public CompareMatcher ignoreComments() {
+        diffBuilder.ignoreComments();
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#withNodeMatcher(NodeMatcher)
+     */
+    public CompareMatcher withNodeMatcher(NodeMatcher nodeMatcher) {
+        diffBuilder.withNodeMatcher(nodeMatcher);
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#withDifferenceEvaluator(DifferenceEvaluator)
+     */
+    public CompareMatcher withDifferenceEvaluator(DifferenceEvaluator differenceEvaluator) {
+        diffBuilder.withDifferenceEvaluator(differenceEvaluator);
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#withComparisonListeners(ComparisonListener...)
+     */
+    public CompareMatcher withComparisonListeners(ComparisonListener... comparisonListeners) {
+        diffBuilder.withComparisonListeners(comparisonListeners);
+        return this;
+    }
+
+    /**
+     * @see DiffBuilder#withDifferenceListeners(ComparisonListener...)
+     */
+    public CompareMatcher withDifferenceListeners(ComparisonListener... comparisonListeners) {
+        diffBuilder.withDifferenceListeners(comparisonListeners);
+        return this;
+    }
+
+    /**
+     * Instead of simple Matcher return <code>false</code> a {@link org.junit.ComparisonFailure} will be thrown.
+     * <p>
+     * The advantage over the standard Matcher behavior is, that the ComparisonFailure can provide the effected
+     * Control-Node and Test-Node in separate Properties.<br />
+     * Eclipse, NetBeans and IntelliJ can provide a nice DIFF-View for the two values.<br />
+     * ComparisonFailure is also used in {@link org.junit.Assert#assertEquals(Object, Object)} if both values are
+     * {@link String}s.
+     * <p>
+     * The only disadvantage is, that you cann't combine the {@link CompareMatcher} with other Matchers
+     * (like {@link org.hamcrest.CoreMatchers#not(Object)}) anymore. The following code will NOT WORKING properly:
+     * <code>assertThat(test, not(isSimilarTo(control).throwComparisonFailure()))</code> 
+     */
+    public CompareMatcher throwComparisonFailure() {
+        throwComparisonFailure = true;
+        return this;
+    }
+
+    /**
+     * Use a custom Formatter for the Error Messages. The defaultFormatter is {@link DefaultComparisonFormatter}.
+     */
+    public CompareMatcher withComparisonFormatter(ComparisonFormatter comparisonFormatter) {
+        this.comparisonFormatter = comparisonFormatter;
+        return this;
+    }
+
+    @Override
+    public boolean matches(Object item) {
+
+        if (checkFor == ComparisonResult.EQUAL) {
+            diffBuilder.withComparisonController(ComparisonControllers.StopWhenSimilar);
+        } else if (checkFor == ComparisonResult.SIMILAR) {
+            diffBuilder.withComparisonController(ComparisonControllers.StopWhenDifferent);
+        }
+
+        diffResult = diffBuilder.withTest(item).build();
+
+        if (!diffResult.getDifferences().iterator().hasNext()) {
+            return true;
+        }
+
+        if (throwComparisonFailure) {
+            AssertionError assertionError = createComparisonFailure();
+            if (assertionError != null)
+                throw assertionError;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return an instants of {@link org.junit.ComparisonFailure} or <code>null</code> if the class is not available.
+     */
+    private AssertionError createComparisonFailure() {
+
+        final Comparison difference = diffResult.getDifferences().iterator().next().getComparison();
+        final String reason = createReasonPrefix(diffResult.getControlSource().getSystemId(), difference);
+        final String controlString = comparisonFormatter.getDetails(difference.getControlDetails(), difference
+            .getType(), formatXml);
+        final String testString = comparisonFormatter.getDetails(difference.getTestDetails(), difference.getType(),
+            formatXml);
+
+        return createComparisonFailure(reason, controlString, testString);
+    }
+
+    /**
+     * Calls the Constructor {@link org.junit.ComparisonFailure#ComparisonFailure(String, String, String)} with
+     * reflections and return <code>null</code> if the {@link org.junit.ComparisonFailure} class is not available.
+     */
+    private AssertionError createComparisonFailure(final String reason, final String controlString,
+            final String testString) {
+        try {
+            if (comparisonFailureConstructor == null) {
+                final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+                Class<?> comparisonFailureClass = classLoader.loadClass("org.junit.ComparisonFailure");
+                comparisonFailureConstructor = comparisonFailureClass.getConstructor(String.class, String.class,
+                    String.class);
+            }
+            return (AssertionError) comparisonFailureConstructor.newInstance(reason, controlString, testString);
+        } catch (Exception e) {
+            // ClassNotFoundException, NoSuchMethodException, InstantiationException,
+            // IllegalAccessException, InvocationTargetException
+            LOGGER.info("Either add junit to your classpath or do not call '.throwComparisonFailure()'. " + e);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        final Comparison difference = diffResult.getDifferences().iterator().next().getComparison();
+        final String reason = createReasonPrefix(diffResult.getControlSource().getSystemId(), difference);
+        final String testString = comparisonFormatter.getDetails(difference.getControlDetails(), difference.getType(),
+            formatXml);
+
+        description.appendText(String.format("%s:\n%s", reason, testString));
+    }
+
+    private String createReasonPrefix(final String systemId, final Comparison difference) {
+        final String description = comparisonFormatter.getDescription(difference);
+        final String reason;
+        if (systemId == null) {
+            reason = description;
+        } else {
+            reason = String.format("In Source '%s' %s", systemId, description);
+        }
+        return reason;
+    }
+
+    @Override
+    public void describeMismatch(final Object item, final Description description) {
+        final Comparison difference = diffResult.getDifferences().iterator().next().getComparison();
+        final String controlString = comparisonFormatter.getDetails(difference.getTestDetails(), difference.getType(),
+            formatXml);
+
+        description.appendText(String.format("result was: \n%s", controlString));
+    }
+}

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/CompareMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/CompareMatcherTest.java
@@ -1,0 +1,427 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package org.xmlunit.matchers;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
+
+import org.xmlunit.builder.Input;
+import org.xmlunit.builder.Input.Builder;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.Comparison.Detail;
+import org.xmlunit.diff.ComparisonFormatter;
+import org.xmlunit.diff.ComparisonListener;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.ComparisonType;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.DifferenceEvaluator;
+import org.xmlunit.diff.ElementSelectors;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.ComparisonFailure;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Node;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.stream.StreamResult;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class CompareMatcherTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /** set this to true for manual review of the Error Messages, how the really looks in your IDE. */
+    private final boolean letExceptionTestFail = false;
+
+    @Test
+    public void testIsIdenticalTo_withAssertionErrorForAttributes_throwsReadableMessage() {
+        // Expected Exception
+        expect(AssertionError.class);
+        expectMessage("Expected attribute value 'xy' but was 'xyz'");
+        expectMessage("at /Element[1]/@attr2");
+        expectMessage("attr2=\"xyz\"");
+
+        // run test:
+        assertThat("<Element attr2=\"xyz\" attr1=\"12\"/>", isIdenticalTo("<Element attr1=\"12\" attr2=\"xy\"/>"));
+    }
+
+    @Test
+    public void testIsIdenticalTo_withAssertionErrorForElementOrder_throwsReadableMessage() {
+        // Expected Exception
+        expect(AssertionError.class);
+        expectMessage("Expected child nodelist sequence '0' but was '1'");
+        expectMessage("comparing <b...> at /a[1]/b[1] to <b...> at /a[1]/b[1]");
+
+        // run test:
+        assertThat("<a><c/><b/></a>", isIdenticalTo("<a><b/><c/></a>")
+            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
+    }
+
+    @Test
+    public void testIsSimilarTo_withAssertionErrorForElementOrder_throwsReadableMessage() {
+        // run test:
+        assertThat("<a><c/><b/></a>", isSimilarTo("<a><b/><c/></a>")
+            .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
+    }
+
+    @Test
+    public void testIsIdenticalTo_withAssertionErrorForWhitespaces_throwsReadableMessage() {
+        // Expected Exception
+        expect(AssertionError.class);
+        expectMessage("Expected child nodelist length '1' but was '3'");
+        expectMessage("<a>" + getLineSeparator()  + "  <b/>" + getLineSeparator()  + "</a>");
+        expectMessage("<a><b/></a>");
+
+        // run test:
+        assertThat("<a>\n  <b/>\n</a>", isIdenticalTo("<a><b/></a>"));
+    }
+
+    @Test
+    public void testIsIdenticalTo_withComparisonFailureForWhitespaces_throwsReadableMessage() {
+        // Expected Exception
+        expect(ComparisonFailure.class);
+        expectMessage("Expected child nodelist length '1' but was '3'");
+        expectMessage("expected:<<a>[<b/>]</a>> but was:<<a>[" + getLineSeparator()  + "  <b/>" + getLineSeparator()  + "]</a>>");
+
+        // run test:
+        assertThat("<a>\n  <b/>\n</a>", isIdenticalTo("<a><b/></a>").throwComparisonFailure());
+    }
+
+    @Test
+    public void testIsIdenticalTo_withIgnoreWhitespaces_shouldSucceed() {
+
+        // run test:
+        assertThat("<a>\n  <b/>\n</a>", isIdenticalTo("<a><b/></a>").ignoreWhitespace());
+    }
+
+    @Test
+    public void testIsIdenticalTo_withIgnoreComments_shouldSucceed() {
+
+        // run test:
+        assertThat("<a><!-- test --></a>", isIdenticalTo("<a></a>").ignoreComments());
+    }
+
+    @Test
+    public void testIsIdenticalTo_withNormalizeWhitespace_shouldSucceed() {
+
+        // run test:
+        assertThat("<a>\n  <b>\n  Test\n  Node\n  </b>\n</a>", isIdenticalTo("<a><b>Test Node</b></a>")
+            .normalizeWhitespace());
+    }
+
+    @Test
+    public void testIsIdenticalTo_withNormalizeWhitespace_shouldFail() {
+
+        expect(AssertionError.class);
+        expectMessage("Expected text value 'TestNode' but was 'Test Node'");
+
+        // run test:
+        assertThat("<a>\n  <b>\n  Test\n  Node\n  </b>\n</a>", isIdenticalTo("<a><b>TestNode</b></a>")
+            .normalizeWhitespace());
+    }
+
+    @Test
+    public void testIsSimilarTo_withFileInput() {
+        expect(AssertionError.class);
+        expectMessage("In Source");
+        expectMessage("test2.xml");
+
+        // run test:
+        assertThat(new File("../test-resources/test1.xml"), isSimilarTo(new File("../test-resources/test2.xml")));
+    }
+
+    @Test
+    public void testIsSimilarTo_withDifferenceEvaluator_shouldSucceed() {
+        // prepare testData
+        final String control = "<a><b attr=\"abc\"></b></a>";
+        final String test = "<a><b attr=\"xyz\"></b></a>";
+
+        // run test
+        assertThat(test, isSimilarTo(control).withDifferenceEvaluator(new IgnoreAttributeDifferenceEvaluator("attr")));
+
+    }
+
+    @Test
+    public void testIsSimilarTo_withComparisonFormatter_shouldFailWithCustomMessage() {
+        // prepare testData
+        expect(AssertionError.class);
+        expectMessage("DESCRIPTION");
+        expectMessage("DETAIL-abc");
+        expectMessage("DETAIL-xyz");
+
+        final String control = "<a><b attr=\"abc\"></b></a>";
+        final String test = "<a><b attr=\"xyz\"></b></a>";
+
+        // run test
+        assertThat(test, isSimilarTo(control).withComparisonFormatter(new DummyComparisonFormatter()));
+
+    }
+
+    @Test
+    public void testIsSimilarTo_withComparisonFormatterAndThrowComparisonFailure_shouldFailWithCustomMessage() {
+        // prepare testData
+        expect(ComparisonFailure.class);
+        expectMessage("DESCRIPTION");
+        expectMessage("DETAIL-[abc]");
+        expectMessage("DETAIL-[xyz]");
+
+        final String control = "<a><b attr=\"abc\"></b></a>";
+        final String test = "<a><b attr=\"xyz\"></b></a>";
+
+        // run test
+        assertThat(test, isSimilarTo(control).withComparisonFormatter(new DummyComparisonFormatter()).throwComparisonFailure());
+
+    }
+
+    @Test
+    public void testIsSimilarTo_withComparisonListener_shouldCollectChanges() {
+        CounterComparisonListener comparisonListener = new CounterComparisonListener();
+        String controlXml = "<a><b>Test Value</b><c>ABC</c></a>";
+        String testXml = "<a><b><![CDATA[Test Value]]></b><c>XYZ</c></a>";
+
+        // run test:
+        try {
+            assertThat(testXml, isSimilarTo(controlXml).withComparisonListeners(comparisonListener));
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("Expected text value 'ABC' but was 'XYZ'"));
+        }
+        
+        // validate result
+        assertThat(comparisonListener.differents, is(1));
+        assertThat(comparisonListener.similars, is(1));
+        assertThat(comparisonListener.equals, is(Matchers.greaterThan(10)));
+    }
+
+    @Test
+    public void testIsSimilarTo_withDifferenceListener_shouldCollectChanges() {
+        CounterComparisonListener comparisonListener = new CounterComparisonListener();
+        String controlXml = "<a><b>Test Value</b><c>ABC</c></a>";
+        String testXml = "<a><b><![CDATA[Test Value]]></b><c>XYZ</c></a>";
+
+        // run test:
+        try {
+            assertThat(testXml, isSimilarTo(controlXml).withDifferenceListeners(comparisonListener));
+            Assert.fail("Should throw AssertionError");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("Expected text value 'ABC' but was 'XYZ'"));
+        }
+        
+        // validate result
+        assertThat(comparisonListener.differents, is(1));
+        assertThat(comparisonListener.similars, is(1));
+        assertThat(comparisonListener.equals, is(0));
+    }
+
+    @Test
+    public void testCompareMatcherWrapper_shouldWriteFailedTestInput() {
+        
+        final String control = "<a><b attr=\"abc\"></b></a>";
+        final String test = "<a><b attr=\"xyz\"></b></a>";
+
+        // run test
+        final String fileName = "testCompareMatcherWrapper.xml";
+        try {
+            assertThat(test, TestCompareMatcherWrapper.isSimilarTo(control).withTestFileName(fileName));
+            Assert.fail("Should throw AssertionError");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("Expected attribute value 'abc' but was 'xyz'"));
+        }
+        
+        // validate that the written File contains the right data:
+        assertThat(new File(getTestResultFolder(), fileName), isSimilarTo(test));
+    }
+
+    public void expect(Class<? extends Throwable> type) {
+        if (letExceptionTestFail) return;
+        thrown.expect(type);
+    }
+
+    public void expectMessage(String substring) {
+        if (letExceptionTestFail) return;
+        thrown.expectMessage(substring);
+    }
+
+    private String getLineSeparator() {
+        return System.getProperty("line.separator");
+    }
+
+    private final class DummyComparisonFormatter implements ComparisonFormatter {
+
+        @Override
+        public String getDetails(Detail details, ComparisonType type, boolean formatXml) {
+            return "DETAIL-" + details.getValue();
+        }
+
+        @Override
+        public String getDescription(Comparison difference) {
+            return "DESCRIPTION";
+        }
+    }
+
+    private final class IgnoreAttributeDifferenceEvaluator implements DifferenceEvaluator {
+
+        private final String attributeName;
+
+        public IgnoreAttributeDifferenceEvaluator(String attributeName) {
+            this.attributeName = attributeName;
+        }
+
+        @Override
+        public ComparisonResult evaluate(Comparison comparison, ComparisonResult outcome) {
+            final Node controlNode = (Node) comparison.getControlDetails().getTarget();
+            if (controlNode instanceof Attr) {
+                Attr attr = (Attr) controlNode;
+                if (attr.getName().equals(attributeName)) {
+                    return ComparisonResult.EQUAL;
+                }
+            }
+            return outcome;
+        }
+    }
+
+    private final class CounterComparisonListener implements ComparisonListener {
+
+        private int equals;
+        private int similars;
+        private int differents;
+
+        @Override
+        public void comparisonPerformed(Comparison comparison, ComparisonResult outcome) {
+            switch (outcome) {
+            case EQUAL:
+                equals++;
+                break;
+            case SIMILAR:
+                similars++;
+                break;
+            case DIFFERENT:
+                differents++;
+                break;
+
+            default:
+                break;
+            }
+        }
+
+    }
+
+    /**
+     * Example Wrapper for {@link CompareMatcher}.
+     * <p>
+     * This example will write the Test-Input into the Files System.<br>
+     * This could be useful for manual reviews or as template for a control-File.
+     * 
+     */
+    private static class TestCompareMatcherWrapper extends BaseMatcher<Object> {
+        private final CompareMatcher compareMatcher;
+        private String fileName;
+        protected TestCompareMatcherWrapper(CompareMatcher compareMatcher) {
+            this.compareMatcher = compareMatcher;
+        }
+        public TestCompareMatcherWrapper withTestFileName(String fileName) {
+            this.fileName = fileName;
+            return this;
+        }
+
+        public static TestCompareMatcherWrapper isSimilarTo(final Object control) {
+            return new TestCompareMatcherWrapper(CompareMatcher.isSimilarTo(control));
+        }
+
+        @Override
+        public boolean matches(Object testItem) {
+            if (fileName == null) {
+                return compareMatcher.matches(testItem);
+            }
+            // do something with your Test-Source
+            final Builder builder = Input.from(testItem);
+            // e.g.: write the testItem into the FilesSystem. So it can be used as template for a new control-File.
+            final File testFile = writeIntoTestResultFolder(builder.build());
+            return compareMatcher.matches(testFile);
+        }
+
+        private File writeIntoTestResultFolder(final Source source) throws TransformerFactoryConfigurationError {
+            FileOutputStream fop = null;
+            File file = new File(getTestResultFolder(), this.fileName);
+            try {
+                if (!file.exists()) {
+                    file.createNewFile();
+                }
+                fop = new FileOutputStream(file);
+                marshal(source, fop);
+                fop.flush();
+                fop.close();
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                if (fop != null) {
+                    try {
+                        fop.close();
+                    } catch (IOException e) {
+                        // ignore exception during close
+                    }
+                }
+            }
+            return file;
+        }
+
+        private void marshal(final Source source, FileOutputStream fop)
+                throws TransformerFactoryConfigurationError, TransformerConfigurationException, TransformerException {
+            StreamResult r = new StreamResult(fop);
+            TransformerFactory fac = TransformerFactory.newInstance();
+            Transformer t = fac.newTransformer();
+            t.transform(source, r);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            compareMatcher.describeTo(description);
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description description) {
+            compareMatcher.describeMismatch(item, description);
+        }
+        
+    }
+
+    private static File getTestResultFolder() {
+        final File folder = new File(//
+            String.format("./target/testResults/%s", CompareMatcherTest.class.getSimpleName()));
+        if (!folder.exists()) {
+            folder.mkdirs();
+        }
+        return folder;
+    }
+}


### PR DESCRIPTION
This Hamcrest Matcher compares two XML sources with each others. 

## Input
The Test-Object and Control-Object can be all types of input supported by Input.from(Object):
 * javax.xml.transform.Source
 * org.xmlunit.builder.Input.Builder
 * org.w3c.dom.Document
 * org.w3c.dom.Node
 * byte[] (XML as byte[])
 * java.lang.String (XML as String),
 * java.io.File (contains XML)
 * java.net.URL (to a XML-Document)
 * java.net.URI (to a XML-Document)
 * java.io.InputStream
 * java.nio.channels.ReadableByteChannel
 * a Jaxb-Object (an Object marshal-able with javax.xml.bind.JAXB.marshal(...))

## Simple Example
This example will throw an AssertionError: "Expected attribute value 'abc' but was 'xyz'". 
```java
 final String control = "<a><b attr=\"abc\"></b></a>";
 final String test = "<a><b attr=\"xyz\"></b></a>";
 
 assertThat(test, CompareMatcher.isIdenticalTo(control));
```

## Complex Example
In most cases you will have a static factory method for your project which wraps all project-specific configurations like customized ElementSelector or DifferenceEvaluator. 
```java
 public static CompareMatcher isMyProjSimilarTo(final File file) {
     return CompareMatcher.isSimilarTo(file)
         .throwComparisonFailure()
         .normalizeWhitespace()
         .ignoreComments()
         .withNodeMatcher(new DefaultNodeMatcher(new MyElementSelector()))
         .withDifferenceEvaluator(DifferenceEvaluators.chain(
             DifferenceEvaluators.Default, new MyDifferenceEvaluator()));
 }
```
And then somewhere in your Tests:
```java
 assertThat(test, isMyProjSimilarTo(controlFile));
```
 
