### PR TITLE
Renaming Input.fromMemory() to Input.fromString(...) and Input.fromByteArray(...)

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * <pre>
  * String controlXml = &quot;&lt;a&gt;&lt;b&gt;Test Value&lt;/b&gt;&lt;/a&gt;&quot;;
  * String testXml = &quot;&lt;a&gt;\n &lt;b&gt;\n  Test Value\n &lt;/b&gt;\n&lt;/a&gt;&quot;;
- * Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml)).withTest(Input.fromMemory(testXml))
+ * Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml)).withTest(Input.fromString(testXml))
  *     .checkForSimilar()
  *     .ignoreWhitespace()
  *     .build();

--- a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
@@ -111,7 +111,7 @@ public class Input {
         } else if (object instanceof Node) {
             xml = Input.fromNode((Node) object);
         } else if (object instanceof byte[]) {
-            xml = Input.fromMemory((byte[]) object);
+            xml = Input.fromByteArray((byte[]) object);
         } else if (object instanceof String) {
             xml = Input.fromString((String) object);
         } else if (object instanceof File) {
@@ -176,7 +176,7 @@ public class Input {
     /**
      * Build a Source from an array of bytes.
      */
-    public static Builder fromMemory(byte[] b) {
+    public static Builder fromByteArray(byte[] b) {
         return fromStream(new ByteArrayInputStream(b));
     }
 
@@ -204,7 +204,7 @@ public class Input {
                     }
                 }
                 StreamBuilder b =
-                    (StreamBuilder) fromMemory(baos.toByteArray());
+                    (StreamBuilder) fromByteArray(baos.toByteArray());
                 try {
                     b.setSystemId(url.toURI().toString());
                 } catch (URISyntaxException use) {

--- a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
@@ -113,7 +113,7 @@ public class Input {
         } else if (object instanceof byte[]) {
             xml = Input.fromMemory((byte[]) object);
         } else if (object instanceof String) {
-            xml = Input.fromMemory((String) object);
+            xml = Input.fromString((String) object);
         } else if (object instanceof File) {
             xml = Input.fromFile((File) object);
         } else if (object instanceof URL) {
@@ -169,7 +169,7 @@ public class Input {
     /**
      * Build a Source from a string.
      */
-    public static Builder fromMemory(String s) {
+    public static Builder fromString(String s) {
         return fromReader(new StringReader(s));
     }
 

--- a/xmlunit-core/src/test/java/org/xmlunit/builder/DiffBuilderTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/builder/DiffBuilderTest.java
@@ -37,7 +37,6 @@ import org.w3c.dom.Node;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 
@@ -50,8 +49,8 @@ public class DiffBuilderTest {
         String testXml = "<a>\n <b>\n  Test Value\n </b>\n</a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .build();
 
         // validate result
@@ -66,8 +65,8 @@ public class DiffBuilderTest {
         String testXml = "<a>\n <b>\n  Test Value\n </b>\n</a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .ignoreWhitespace()
                       .build();
 
@@ -83,8 +82,8 @@ public class DiffBuilderTest {
         String testXml = "<a>\n <b>\n  Test Value\n </b>\n</a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .build();
 
         // validate result
@@ -99,8 +98,8 @@ public class DiffBuilderTest {
         String testXml = "<a>\n <b>\n  Test Value\n </b>\n</a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .normalizeWhitespace()
                       .build();
 
@@ -116,8 +115,8 @@ public class DiffBuilderTest {
         String testXml = "<a><![CDATA[Test Value]]></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .checkForIdentical()
                       .build();
 
@@ -133,8 +132,8 @@ public class DiffBuilderTest {
         String testXml = "<a><![CDATA[Test Value]]></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                      .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                      .withTest(Input.fromString(testXml).build())
                       .checkForSimilar()
                       .build();
 
@@ -149,8 +148,8 @@ public class DiffBuilderTest {
         String testXml = "<a><b><!-- An other comment -->Test Value</b></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                    .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                    .withTest(Input.fromString(testXml).build())
                     .build();
 
         // validate result
@@ -165,8 +164,8 @@ public class DiffBuilderTest {
         String testXml = "<a><b><!-- An other comment -->Test Value</b></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build())
-                                .withTest(Input.fromMemory(testXml).build())
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build())
+                                .withTest(Input.fromString(testXml).build())
                                 .ignoreComments()
                                 .build();
 
@@ -181,7 +180,7 @@ public class DiffBuilderTest {
         String controlXml = "<a><b>Test Value</b></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml).build()).withTest(controlXml)
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml).build()).withTest(controlXml)
                 .build();
 
         // validate result
@@ -195,8 +194,8 @@ public class DiffBuilderTest {
         String controlXml = "<a><b>Test Value</b></a>";
 
         // run test
-        Diff myDiff = DiffBuilder.compare(Input.fromMemory(controlXml))
-                .withTest(Input.fromMemory(controlXml))
+        Diff myDiff = DiffBuilder.compare(Input.fromString(controlXml))
+                .withTest(Input.fromString(controlXml))
                 .build();
 
         // validate result

--- a/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
@@ -106,7 +106,7 @@ public class InputTest {
     }
 
     @Test public void shouldParseString() throws Exception {
-        allIsWellFor(Input.fromMemory(new String(readTestFile(), "UTF-8"))
+        allIsWellFor(Input.fromString(new String(readTestFile(), "UTF-8"))
                      .build());
     }
 
@@ -129,7 +129,7 @@ public class InputTest {
     }
 
     @Test public void shouldParseATransformationFromSource() throws Exception {
-        Source input = Input.fromMemory("<animal>furry</animal>").build();
+        Source input = Input.fromString("<animal>furry</animal>").build();
         Source s = Input.byTransforming(input)
             .withStylesheet(Input.fromFile(TestResources.ANIMAL_XSL)
                             .build())
@@ -138,7 +138,7 @@ public class InputTest {
     }
 
     @Test public void shouldParseATransformationFromBuilder() throws Exception {
-        Input.Builder input = Input.fromMemory("<animal>furry</animal>");
+        Input.Builder input = Input.fromString("<animal>furry</animal>");
         Source s = Input.byTransforming(input)
             .withStylesheet(Input.fromFile(TestResources.ANIMAL_XSL))
             .build();

--- a/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
@@ -111,7 +111,7 @@ public class InputTest {
     }
 
     @Test public void shouldParseBytes() throws Exception {
-        allIsWellFor(Input.fromMemory(readTestFile()).build());
+        allIsWellFor(Input.fromByteArray(readTestFile()).build());
     }
 
     @Test public void shouldParseFileFromURIString() throws Exception {
@@ -151,9 +151,9 @@ public class InputTest {
 
     @Test public void shouldParseUnknownToSource() throws Exception {
         // from Source
-        allIsWellFor(Input.from(Input.fromMemory(readTestFile()).build()).build());
+        allIsWellFor(Input.from(Input.fromByteArray(readTestFile()).build()).build());
         // from Builder
-        allIsWellFor(Input.from(Input.fromMemory(readTestFile())).build());
+        allIsWellFor(Input.from(Input.fromByteArray(readTestFile())).build());
         // from Document
         allIsWellFor(Input.from(parse(Input.fromFile(TestResources.ANIMAL_FILE).build())).build());
         // from File

--- a/xmlunit-core/src/test/java/org/xmlunit/diff/DOMDifferenceEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/diff/DOMDifferenceEngineTest.java
@@ -13,7 +13,6 @@
 */
 package org.xmlunit.diff;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.dom.DOMSource;
 import org.xmlunit.NullNode;
@@ -327,13 +326,13 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
                 }
             });
         d.setComparisonController(ComparisonControllers.StopWhenDifferent);
-        Document d1 = Convert.toDocument(Input.fromMemory("<Book/>").build());
+        Document d1 = Convert.toDocument(Input.fromString("<Book/>").build());
         Document d2 =
-            Convert.toDocument(Input.fromMemory("<!DOCTYPE Book PUBLIC "
-                                                + "\"XMLUNIT/TEST/PUB\" "
-                                                + "\"" + TestResources.BOOK_DTD
-                                                + "\">"
-                                                + "<Book/>")
+            Convert.toDocument(Input.fromString("<!DOCTYPE Book PUBLIC "
+                    + "\"XMLUNIT/TEST/PUB\" "
+                    + "\"" + TestResources.BOOK_DTD
+                    + "\">"
+                    + "<Book/>")
                                .build());
         assertEquals(wrapAndStop(ComparisonResult.DIFFERENT),
                      d.compareNodes(d1, new XPathContext(),
@@ -345,12 +344,12 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
         d.addDifferenceListener(ex);
         d.setComparisonController(ComparisonControllers.StopWhenDifferent);
 
-        d1 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.0\""
-                                                 + " encoding=\"UTF-8\"?>"
-                                                 + "<Book/>").build());
-        d2 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.1\""
-                                                 + " encoding=\"UTF-8\"?>"
-                                                 + "<Book/>").build());
+        d1 = Convert.toDocument(Input.fromString("<?xml version=\"1.0\""
+                + " encoding=\"UTF-8\"?>"
+                + "<Book/>").build());
+        d2 = Convert.toDocument(Input.fromString("<?xml version=\"1.1\""
+                + " encoding=\"UTF-8\"?>"
+                + "<Book/>").build());
         assertEquals(wrapAndStop(ComparisonResult.DIFFERENT),
                      d.compareNodes(d1, new XPathContext(),
                                     d2, new XPathContext()));
@@ -361,12 +360,12 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
         d.addDifferenceListener(ex);
         d.setComparisonController(ComparisonControllers.StopWhenDifferent);
 
-        d1 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.0\""
-                                                 + " standalone=\"yes\"?>"
-                                                 + "<Book/>").build());
-        d2 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.0\""
-                                                 + " standalone=\"no\"?>"
-                                                 + "<Book/>").build());
+        d1 = Convert.toDocument(Input.fromString("<?xml version=\"1.0\""
+                + " standalone=\"yes\"?>"
+                + "<Book/>").build());
+        d2 = Convert.toDocument(Input.fromString("<?xml version=\"1.0\""
+                + " standalone=\"no\"?>"
+                + "<Book/>").build());
         assertEquals(wrapAndStop(ComparisonResult.DIFFERENT),
                      d.compareNodes(d1, new XPathContext(),
                                     d2, new XPathContext()));
@@ -389,12 +388,12 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
             });
         d.setComparisonController(ComparisonControllers.StopWhenDifferent);
 
-        d1 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.0\""
-                                                 + " encoding=\"UTF-8\"?>"
-                                                 + "<Book/>").build());
-        d2 = Convert.toDocument(Input.fromMemory("<?xml version=\"1.0\""
-                                                 + " encoding=\"UTF-16\"?>"
-                                                 + "<Book/>").build());
+        d1 = Convert.toDocument(Input.fromString("<?xml version=\"1.0\""
+                + " encoding=\"UTF-8\"?>"
+                + "<Book/>").build());
+        d2 = Convert.toDocument(Input.fromString("<?xml version=\"1.0\""
+                + " encoding=\"UTF-16\"?>"
+                + "<Book/>").build());
         assertEquals(wrapAndStop(ComparisonResult.DIFFERENT),
                      d.compareNodes(d1, new XPathContext(),
                                     d2, new XPathContext()));
@@ -918,6 +917,6 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
     }
 
     private Document documentForString(String s) {
-        return Convert.toDocument(Input.fromMemory(s).build());
+        return Convert.toDocument(Input.fromString(s).build());
     }
 }

--- a/xmlunit-core/src/test/java/org/xmlunit/diff/DefaultComparisonFormatterTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/diff/DefaultComparisonFormatterTest.java
@@ -103,7 +103,7 @@ public class DefaultComparisonFormatterTest {
     public void testComparisonType_HAS_DOCTYPE_DECLARATION() throws Exception {
         // prepare data
         DocumentBuilderFactory dbf = getDocumentBuilderFactoryWithoutValidation();
-        Document controlDoc = Convert.toDocument(Input.fromMemory("<!DOCTYPE Book><a/>").build(), dbf);
+        Document controlDoc = Convert.toDocument(Input.fromString("<!DOCTYPE Book><a/>").build(), dbf);
 
         Diff diff = DiffBuilder.compare(controlDoc).withTest("<a/>").build();
         assertPreRequirements(diff, ComparisonType.HAS_DOCTYPE_DECLARATION);
@@ -126,8 +126,8 @@ public class DefaultComparisonFormatterTest {
     public void testComparisonType_DOCTYPE_NAME() throws Exception {
         // prepare data
         DocumentBuilderFactory dbf = getDocumentBuilderFactoryWithoutValidation();
-        Document controlDoc = Convert.toDocument(Input.fromMemory("<!DOCTYPE Book ><a/>").build(), dbf);
-        Document testDoc = Convert.toDocument(Input.fromMemory("<!DOCTYPE XY ><a/>").build(), dbf);
+        Document controlDoc = Convert.toDocument(Input.fromString("<!DOCTYPE Book ><a/>").build(), dbf);
+        Document testDoc = Convert.toDocument(Input.fromString("<!DOCTYPE XY ><a/>").build(), dbf);
 
         Diff diff = DiffBuilder.compare(controlDoc).withTest(testDoc).build();
         assertPreRequirements(diff, ComparisonType.DOCTYPE_NAME);
@@ -150,9 +150,9 @@ public class DefaultComparisonFormatterTest {
     public void testComparisonType_DOCTYPE_PUBLIC_ID() throws Exception {
         // prepare data
         DocumentBuilderFactory dbf = getDocumentBuilderFactoryWithoutValidation();
-        Document controlDoc = Convert.toDocument(Input.fromMemory(
+        Document controlDoc = Convert.toDocument(Input.fromString(
                 "<!DOCTYPE Book PUBLIC \"XMLUNIT/TEST/PUB\" \"http://example.org/nonsense\"><a/>").build(), dbf);
-        Document testDoc = Convert.toDocument(Input.fromMemory(
+        Document testDoc = Convert.toDocument(Input.fromString(
                 "<!DOCTYPE Book SYSTEM \"http://example.org/nonsense\"><a/>").build(), dbf);
 
         Diff diff = DiffBuilder.compare(controlDoc).withTest(testDoc).build();
@@ -177,9 +177,9 @@ public class DefaultComparisonFormatterTest {
     public void testComparisonType_DOCTYPE_SYSTEM_ID() throws Exception {
         // prepare data
         DocumentBuilderFactory dbf = getDocumentBuilderFactoryWithoutValidation();
-        Document controlDoc = Convert.toDocument(Input.fromMemory(
+        Document controlDoc = Convert.toDocument(Input.fromString(
                 "<!DOCTYPE Book PUBLIC \"XMLUNIT/TEST/PUB\" \"http://example.org/nonsense\"><a/>").build(), dbf);
-        Document testDoc = Convert.toDocument(Input.fromMemory(
+        Document testDoc = Convert.toDocument(Input.fromString(
                 "<!DOCTYPE Book PUBLIC \"XMLUNIT/TEST/PUB\" \"http://example.org/404\"><a/>").build(), dbf);
 
         Diff diff = DiffBuilder.compare(controlDoc).withTest(testDoc).build();

--- a/xmlunit-core/src/test/java/org/xmlunit/util/NodesTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/util/NodesTest.java
@@ -16,7 +16,6 @@ package org.xmlunit.util;
 import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.xmlunit.builder.Input;
 import org.junit.Before;
@@ -145,15 +144,15 @@ public class NodesTest {
     }
 
     private Document handleWsSetup() {
-        return Convert.toDocument(Input.fromMemory(
-            "<root>\n"
-            + "<!-- trim\tme -->\n"
-            + "<child attr=' trim me ' attr2='not me'>\n"
-            + " trim me \n"
-            + "</child><![CDATA[ trim me ]]>\n"
-            + "<?target  trim me ?>\n"
-            + "<![CDATA[          ]]>\n"
-            + "</root>").build());
+        return Convert.toDocument(Input.fromString(
+                "<root>\n"
+                        + "<!-- trim\tme -->\n"
+                        + "<child attr=' trim me ' attr2='not me'>\n"
+                        + " trim me \n"
+                        + "</child><![CDATA[ trim me ]]>\n"
+                        + "<?target  trim me ?>\n"
+                        + "<![CDATA[          ]]>\n"
+                        + "</root>").build());
     }
 
     private Map.Entry<Document, Node> stripWsSetup() {

--- a/xmlunit-core/src/test/java/org/xmlunit/xpath/AbstractXPathEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/xpath/AbstractXPathEngineTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractXPathEngineTest {
 
     @Test public void selectNodesWithNS() {
         XPathEngine e = getEngine();
-        source = Input.fromMemory("<n:d xmlns:n='urn:test:1'><n:e/></n:d>")
+        source = Input.fromString("<n:d xmlns:n='urn:test:1'><n:e/></n:d>")
             .build();
         HashMap<String, String> m = new HashMap<String, String>();
         m.put("x", "urn:test:1");
@@ -103,7 +103,7 @@ public abstract class AbstractXPathEngineTest {
 
     @Test public void selectNodesWithDefaultNS() {
         XPathEngine e = getEngine();
-        source = Input.fromMemory("<d xmlns='urn:test:1'><e/></d>")
+        source = Input.fromString("<d xmlns='urn:test:1'><e/></d>")
             .build();
         HashMap<String, String> m = new HashMap<String, String>();
         m.put("x", "urn:test:1");
@@ -114,7 +114,7 @@ public abstract class AbstractXPathEngineTest {
 
     @Test public void selectNodesWithDefaultNSEmptyPrefix() {
         XPathEngine e = getEngine();
-        source = Input.fromMemory("<d xmlns='urn:test:1'><e/></d>")
+        source = Input.fromString("<d xmlns='urn:test:1'><e/></d>")
             .build();
         HashMap<String, String> m = new HashMap<String, String>();
         m.put("", "urn:test:1");
@@ -126,7 +126,7 @@ public abstract class AbstractXPathEngineTest {
     // doesn't match
     public void selectNodesWithDefaultNSNoPrefix() {
         XPathEngine e = getEngine();
-        source = Input.fromMemory("<d xmlns='urn:test:1'><e/></d>")
+        source = Input.fromString("<d xmlns='urn:test:1'><e/></d>")
             .build();
         HashMap<String, String> m = new HashMap<String, String>();
         m.put("", "urn:test:1");

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Transform.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Transform.java
@@ -47,7 +47,6 @@ import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXSource;
 import org.custommonkey.xmlunit.exceptions.ConfigurationException;
@@ -77,8 +76,8 @@ public class Transform {
      * @param stylesheet
      */
     public Transform(String input, String stylesheet) {
-        this(input == null ? null : Input.fromMemory(input),
-             stylesheet == null ? null : Input.fromMemory(stylesheet));
+        this(input == null ? null : Input.fromString(input),
+             stylesheet == null ? null : Input.fromString(stylesheet));
     }
 
     /**
@@ -87,7 +86,7 @@ public class Transform {
      * @param stylesheet
      */
     public Transform(String input, File stylesheet) {
-        this(input == null ? null : Input.fromMemory(input),
+        this(input == null ? null : Input.fromString(input),
              stylesheet == null ? null : Input.fromFile(stylesheet));
     }
 
@@ -127,7 +126,7 @@ public class Transform {
      */
     public Transform(Node sourceNode, String stylesheet) {
         this(sourceNode == null ? null : Input.fromNode(sourceNode),
-             stylesheet == null ? null : Input.fromMemory(stylesheet));
+             stylesheet == null ? null : Input.fromString(stylesheet));
     }
 
     /**


### PR DESCRIPTION
Renaming Input.fromMemory() to Input.fromString(...) and Input.fromByteArray(...) for clarity and consistency with other methods in the class.