### PR TITLE
Update legacy XMLUnit.getVersion() returning always the current version

### DIFF
--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XMLUnit.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XMLUnit.java
@@ -541,8 +541,7 @@ public final class XMLUnit {
      * @return current version
      */
     public static String getVersion() {
-        // FIXME should read a property
-        return "2.0.0-SNAPSHOT"; 
+        return XMLUnit.class.getPackage().getImplementationVersion();
     }
 
    /**


### PR DESCRIPTION
It returns the "Implementation-Version" property from the META-INF/MANIFEST.MF containing in the xmlunit-legacy-2.0.0-SNAPSHOT.jar File.