### PR TITLE
Corrected javadoc

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
@@ -91,7 +91,6 @@ public class DiffBuilder {
      * 
      * @see DiffBuilder
      * @param controlSource the expected reference Result.
-     * @param testSource the test result which must be compared with the control source.
      */
     private DiffBuilder(final Source controlSource) {
         this.controlSource = controlSource;

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Diff.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Diff.java
@@ -188,10 +188,10 @@ public class Diff
      *
      * <p>This may involve:</p>
      * <ul>
-     *   <li>{@link XMLUnit.setIgnoreWhitespace stripping redundant
+     *   <li>{@link XMLUnit#setIgnoreWhitespace stripping redundant
      *   whitespace}</li>
-     *   <li>{@link XMLUnit.setIgnoreComments stripping comments}</li>
-     *   <li>{@link XMLUnit.setNormalize normalizing Text nodes}</li>
+     *   <li>{@link XMLUnit#setIgnoreComments stripping comments}</li>
+     *   <li>{@link XMLUnit#setNormalize normalizing Text nodes}</li>
      * </ul>
      *     
      * @param orig a document making up one half of this difference
@@ -202,10 +202,10 @@ public class Diff
     }
 
     /**
-     * Removes all comment nodes if {@link XMLUnit.getIgnoreComments
+     * Removes all comment nodes if {@link XMLUnit#getIgnoreComments
      * comments are ignored}.
      *     
-     * @param originalDoc a document making up one half of this difference
+     * @param orig a document making up one half of this difference
      * @return manipulated doc
      */
     private Document getCommentlessDocument(Document orig) {
@@ -264,10 +264,6 @@ public class Diff
     /**
      * Append a meaningful message to the buffer of messages
      * @param appendTo the messages buffer
-     * @param expected
-     * @param actual
-     * @param control
-     * @param test
      * @param difference
      */
     private void appendDifference(StringBuffer appendTo, Difference difference) {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DifferenceEngine.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DifferenceEngine.java
@@ -818,7 +818,7 @@ public class DifferenceEngine
      * @param control
      * @param test
      * @param listener
-     * @param differenceType
+     * @param difference
      * @throws DifferenceFoundException
      */
     private void compareCharacterData(CharacterData control, CharacterData test,

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameAndAttributeQualifier.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameAndAttributeQualifier.java
@@ -46,7 +46,7 @@ import org.w3c.dom.NamedNodeMap;
 /**
  * More complex interface implementation that tests two elements for tag name
  * and attribute name comparability. 
- * @see DifferenceEngine#compareNodeList(List, List, int, DifferenceListener, ElementQualifier)
+ * @see DifferenceEngine#compareNodeList(java.util.List, java.util.List, int, DifferenceListener, ElementQualifier)
  * @see Diff#overrideElementQualifier(ElementQualifier)
  */
 public class ElementNameAndAttributeQualifier extends ElementNameQualifier {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameAndTextQualifier.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameAndTextQualifier.java
@@ -45,7 +45,7 @@ import org.w3c.dom.Text;
 /**
  * More complex interface implementation that tests two elements for tag name
  * and text content comparability. 
- * @see DifferenceEngine#compareNodeList(List, List, int, DifferenceListener, ElementQualifier)
+ * @see DifferenceEngine#compareNodeList(java.util.List, java.util.List, int, DifferenceListener, ElementQualifier)
  * @see Diff#overrideElementQualifier(ElementQualifier)
  */
 public class ElementNameAndTextQualifier extends ElementNameQualifier {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameQualifier.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementNameQualifier.java
@@ -44,7 +44,7 @@ import org.w3c.dom.Node;
  * Simple interface implementation that tests two elements for name
  * comparability. This class provides the default behaviour within a
  * DifferenceEngine (for backwards compatibility)
- * @see DifferenceEngine#compareNodeList(List, List, int, DifferenceListener, ElementQualifier)
+ * @see DifferenceEngine#compareNodeList(java.util.List, java.util.List, int, DifferenceListener, ElementQualifier)
  * @see Diff#overrideElementQualifier(ElementQualifier)
  */
 public class ElementNameQualifier implements ElementQualifier {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementQualifier.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/ElementQualifier.java
@@ -42,7 +42,7 @@ import org.w3c.dom.Element;
  * Interface used by the DifferenceEngine class to determine which elements can
  * be compared within a NodeList of child nodes.
  * 
- * @see DifferenceEngine#compareNodeList(List, List, int, DifferenceListener, ElementQualifier)
+ * @see DifferenceEngine#compareNodeList(java.util.List, java.util.List, int, DifferenceListener, ElementQualifier)
  * @see Diff#overrideElementQualifier(ElementQualifier)
  */
 

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XpathNodeTracker.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XpathNodeTracker.java
@@ -336,7 +336,7 @@ public class XpathNodeTracker implements XMLConstants {
 
         /**
          * Keep a reference to the visited attribute at the current visited node
-         * @param value the attribute visited
+         * @param visited the attribute visited
          */
         private void trackAttribute(QName visited) {
             if (atAttribute) {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/jaxp13/Jaxp13XpathEngine.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/jaxp13/Jaxp13XpathEngine.java
@@ -106,8 +106,7 @@ public class Jaxp13XpathEngine implements XpathEngine {
      * @param select
      * @param document
      * @return evaluated result
-     * @throws TransformerException
-     * @throws TransformerConfigurationException
+     * @throws XpathException
      */
     public String evaluate(String select, Document document)
         throws XpathException {

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/examples/test_MultiLevelElementNameAndTextQualifier.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/examples/test_MultiLevelElementNameAndTextQualifier.java
@@ -49,7 +49,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 
 /**
  * JUnit testcase for MultiLevelElementNameAndTextQualifier
- * @see test_Diff#testRepeatedElementNamesWithTextQualification()
+ * @see org.custommonkey.xmlunit.test_Diff#testRepeatedElementNamesWithTextQualification()
  */
 public class test_MultiLevelElementNameAndTextQualifier extends TestCase {
     private static final String TAG_NAME = "tagYoureIt";
@@ -120,7 +120,7 @@ public class test_MultiLevelElementNameAndTextQualifier extends TestCase {
     }
         
     /**
-     * @see https://sourceforge.net/forum/forum.php?thread_id=1440169&forum_id=73274
+     * @see <a href="https://sourceforge.net/forum/forum.php?thread_id=1440169&forum_id=73274"/>
      */
     public void testThread1440169() throws Exception {
         String s1 = "<a><b><c>foo</c></b><b><c>bar</c></b></a>";

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/examples/test_RecursiveElementNameAndTextQualifier.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/examples/test_RecursiveElementNameAndTextQualifier.java
@@ -51,7 +51,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 /**
  * JUnit testcase for RecursiveElementNameAndTextQualifier with most
  * tests copied from MultiLevelElementNameAndTextQualifier' test.
- * @see test_Diff#testRepeatedElementNamesWithTextQualification()
+ * @see org.custommonkey.xmlunit.test_Diff#testRepeatedElementNamesWithTextQualification()
  */
 public class test_RecursiveElementNameAndTextQualifier extends TestCase {
     private static final String TAG_NAME = "tagYoureIt";
@@ -122,7 +122,7 @@ public class test_RecursiveElementNameAndTextQualifier extends TestCase {
     }
         
     /**
-     * @see https://sourceforge.net/forum/forum.php?thread_id=1440169&forum_id=73274
+     * @see <a href="https://sourceforge.net/forum/forum.php?thread_id=1440169&forum_id=73274"/>
      */
     public void testThread1440169() throws Exception {
         String s1 = "<a><b><c>foo</c></b><b><c>bar</c></b></a>";
@@ -191,7 +191,7 @@ public class test_RecursiveElementNameAndTextQualifier extends TestCase {
     }
 
     /**
-     * @see https://sourceforge.net/forum/forum.php?thread_id=2948005&amp;forum_id=73273
+     * @see <a href="https://sourceforge.net/forum/forum.php?thread_id=2948005&amp;forum_id=73273"/>
      */
     public void testOpenDiscussionThread2948995_1() throws Exception {
         Diff myDiff = new Diff("<root>"
@@ -235,7 +235,7 @@ public class test_RecursiveElementNameAndTextQualifier extends TestCase {
     }
 
     /**
-     * @see https://sourceforge.net/forum/forum.php?thread_id=2948005&amp;forum_id=73273
+     * @see <a href="https://sourceforge.net/forum/forum.php?thread_id=2948005&amp;forum_id=73273"/>
      */
     public void testOpenDiscussionThread2948995_2() throws Exception {
         Diff myDiff = new Diff("<root>"

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/jaxp13/test_Validator.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/jaxp13/test_Validator.java
@@ -179,7 +179,7 @@ public class test_Validator extends TestCase {
      * latest nightly build (2008-02-13, actually).  The same jars do
      * not work with Java6.</p>
      *
-     * @see http://weblogs.java.net/blog/kohsuke/archive/2006/02/validate_xml_us.html
+     * @see <a href="http://weblogs.java.net/blog/kohsuke/archive/2006/02/validate_xml_us.html"/>
      */
     public void XtestGoodRelaxNGSchemaIsValid() throws Exception {
         Validator v = new Validator(javax.xml.XMLConstants.RELAXNG_NS_URI);

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_DetailedDiff.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_DetailedDiff.java
@@ -197,7 +197,7 @@ public class test_DetailedDiff extends test_Diff {
     }
 
     /**
-     * @see http://sourceforge.net/forum/forum.php?thread_id=1691528&forum_id=73274
+     * @see <a href="http://sourceforge.net/forum/forum.php?thread_id=1691528&forum_id=73274"/>
      */
     public void testHelpForumThread1691528() throws Exception {
         String control = "<table border=\"1\">" 
@@ -227,7 +227,7 @@ public class test_DetailedDiff extends test_Diff {
 
     /**
      * Bug 1860681
-     * @see https://sourceforge.net/tracker/index.php?func=detail&amp;aid=1860681&amp;group_id=23187&amp;atid=377768
+     * @see <a href="https://sourceforge.net/tracker/index.php?func=detail&amp;aid=1860681&amp;group_id=23187&amp;atid=377768"/>
      */
     public void testXpathOfMissingNode() throws Exception {
         String control = 
@@ -364,7 +364,7 @@ public class test_DetailedDiff extends test_Diff {
     }
 
     /**
-     * @see https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3062518&amp;group_id=23187&amp;atid=377768
+     * @see <a href="https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3062518&amp;group_id=23187&amp;atid=377768"/>
      */
     public void testIssue3062518() throws Exception {
         String control = "<Fruits>"

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_Diff.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_Diff.java
@@ -719,7 +719,7 @@ public class test_Diff extends TestCase{
 
     /**
      * Bug Report 1779701
-     * @see http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1779701&amp;group_id=23187&amp;atid=377768
+     * @see <a href="http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1779701&amp;group_id=23187&amp;atid=377768"/>
      */
     public void testWhitespaceAndNamespaces() throws Exception {
 	String control =
@@ -741,7 +741,7 @@ public class test_Diff extends TestCase{
 
     /**
      * Bug Report 1863632
-     * @see http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1863632&amp;group_id=23187&amp;atid=377768
+     * @see <a href="http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1863632&amp;group_id=23187&amp;atid=377768"/>
      */
     public void testBasicWhitespaceHandling() throws Exception {
 	String control = "<a><b/></a>";
@@ -953,7 +953,7 @@ public class test_Diff extends TestCase{
     }
 
     /**
-     * @see https://sourceforge.net/tracker/?func=detail&aid=2807167&group_id=23187&atid=377768
+     * @see <a href="https://sourceforge.net/tracker/?func=detail&aid=2807167&group_id=23187&atid=377768"/>
      */
     public void testIssue2807167() throws Exception {
         String test = "<tag>" +
@@ -1016,7 +1016,7 @@ public class test_Diff extends TestCase{
     }
 
     /**
-     * @see http://sourceforge.net/tracker/?func=detail&atid=377768&aid=3602981&group_id=23187
+     * @see <a href="http://sourceforge.net/tracker/?func=detail&atid=377768&aid=3602981&group_id=23187"/>
      */
     public void testXsiTypeSpecialCase() throws Exception {
         String test = "<ns1:Square xsi:type=\"ns1:Shape\" "

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_DifferenceEngine.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_DifferenceEngine.java
@@ -933,7 +933,7 @@ public class test_DifferenceEngine extends TestCase implements DifferenceConstan
     }
 
     /**
-     * @see http://sourceforge.net/forum/forum.php?thread_id=3284504&forum_id=73274
+     * @see <a href="http://sourceforge.net/forum/forum.php?thread_id=3284504&forum_id=73274"/>
      */
     public void testNamespaceAttributeDifferences() throws Exception {
         String control = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>"

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_ElementNameAndAttributeQualifier.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_ElementNameAndAttributeQualifier.java
@@ -217,7 +217,7 @@ public class test_ElementNameAndAttributeQualifier extends TestCase {
     }
 
     /**
-     * @see https://sourceforge.net/forum/forum.php?thread_id=1135716&forum_id=73274l
+     * @see <a href="https://sourceforge.net/forum/forum.php?thread_id=1135716&forum_id=73274l"/>
      */
     public void testHelpForumThread1135716() throws Exception {
         String control = "<class id=\"c0\"> "

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_ForumMessage4406472.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_ForumMessage4406472.java
@@ -41,7 +41,7 @@ import junit.framework.TestCase;
 import org.w3c.dom.Node;
 
 /**
- * @see http://sf.net/forum/message.php?msg_id=4406472
+ * @see <a href="http://sf.net/forum/message.php?msg_id=4406472"/>
  */
 public class test_ForumMessage4406472 extends TestCase {
 

--- a/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_NewDifferenceEngine.java
+++ b/xmlunit-legacy/src/test/java/org/custommonkey/xmlunit/test_NewDifferenceEngine.java
@@ -471,7 +471,7 @@ public class test_NewDifferenceEngine extends TestCase implements DifferenceCons
     }
 
     /**
-     * @see http://sourceforge.net/forum/forum.php?thread_id=3284504&forum_id=73274
+     * @see <a href="http://sourceforge.net/forum/forum.php?thread_id=3284504&forum_id=73274"/>
      */
     public void testNamespaceAttributeDifferences() throws Exception {
         String control = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>"


### PR DESCRIPTION
Found a few instances where the javadoc could be improved:

    @link; corrected method linking syntax
    @params; removed dead params, corrected names, corrected type linking
    @throws; removed dead throws declarations
    @see; surrounded links with <a href="..."/>