### PR TITLE
fixed xslt stylesheet version  / not tested!

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/input/CommentLessSource.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/input/CommentLessSource.java
@@ -36,7 +36,7 @@ public final class CommentLessSource extends DOMSource {
     }
 
     private static final String STYLE =
-        "<stylesheet xmlns=\"http://www.w3.org/1999/XSL/Transform\">"
+        "<stylesheet version=\"1.0\" xmlns=\"http://www.w3.org/1999/XSL/Transform\">"
         + "<template match=\"node()[not(self::comment())]|@*\"><copy>"
         + "<apply-templates select=\"node()[not(self::comment())]|@*\"/>"
         + "</copy></template>"


### PR DESCRIPTION
I had an Exception using the CommentLessSource classusing Oracles oracle.xml.jaxp.JXSAXTransformerFactory class in the backend:

org.xmlunit.ConfigurationException: oracle.xml.xslt.XSLException: <Line 1, Column 58>: XML-22009: (Error) Attribute 'version' not found in 'stylesheet'.
org.xmlunit.transform.Transformation.transformTo(Transformation.java:188)
org.xmlunit.transform.Transformation.transformToDocument(Transformation.java:220)
org.xmlunit.input.CommentLessSource.<init>(CommentLessSource.java:35)
org.xmlunit.builder.DiffBuilder.wrap(DiffBuilder.java:344)
org.xmlunit.builder.DiffBuilder.build(DiffBuilder.java:330)
de.ec4u.adapter.util.XMLUtil.sameXMLDocuments(XMLUtil.java:51)
de.ec4u.adapter.message.ResponseBuilderTest.test3_Retrieve(ResponseBuilderTest.java:141)
Caused by: javax.xml.transform.TransformerConfigurationException: oracle.xml.xslt.XSLException: <Line 1, Column 58>: XML-22009: (Error) Attribute 'version' not found in 'stylesheet'.
oracle.xml.jaxp.JXSAXTransformerFactory.newTemplates(JXSAXTransformerFactory.java:402)
oracle.xml.jaxp.JXSAXTransformerFactory.newTransformer(JXSAXTransformerFactory.java:291)
org.xmlunit.transform.Transformation.transformTo(Transformation.java:172)

As the Execption indicates there is the version attribute missing. 
A Quote from the XSLT specification:

"An xsl:stylesheet element must have a version attribute, indicating the version of XSLT that the stylesheet requires."

see http://www.w3.org/TR/xslt#section-Stylesheet-Structure

Please be aware that i have NOT tested the solution! 

Kind regards,
Philip