### PR TITLE
fix swapped assignment of CDATA and TEXT constants

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
@@ -21,8 +21,8 @@ import org.w3c.dom.Node;
 public final class DifferenceEvaluators {
     private DifferenceEvaluators() { }
 
-    private static final Short CDATA = Node.TEXT_NODE;
-    private static final Short TEXT = Node.CDATA_SECTION_NODE;
+    private static final Short CDATA = Node.CDATA_SECTION_NODE;
+    private static final Short TEXT = Node.TEXT_NODE;
 
     /**
      * Difference evaluator that just echos the result passed in.


### PR DESCRIPTION
The assignment of the `Node.CDATA_SECTION_NODE` and `Node.TEXT_NODE` values
to the `CDATA` and `TEXT` constants used by `DifferenceEvaluators.Default` was
mixed up.