### PR TITLE
Fixing typo in the signature of withNamespaceContext method.

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/DiffBuilder.java
@@ -265,10 +265,10 @@ public class DiffBuilder {
      * XPath expressions will only use local names for elements and
      * attributes.</p>
      *
-     * @param uri2Prefix maps from namespace URI to prefix.
+     * @param prefix2Uri mapping between prefix and namespace URI
      */
-    public DiffBuilder withNamespaceContext(Map<String, String> uri2Prefix) {
-        namespaceContext = uri2Prefix;
+    public DiffBuilder withNamespaceContext(Map<String, String> prefix2Uri) {
+        namespaceContext = prefix2Uri;
         return this;
     }
 

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/CompareMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/CompareMatcher.java
@@ -203,8 +203,8 @@ public final class CompareMatcher extends BaseMatcher<Object> {
      * @see DiffBuilder#withNamespaceContext(Map)
      * @since XMLUnit 2.0.1
      */
-    public CompareMatcher withNamespaceContext(Map<String, String> uri2Prefix) {
-        diffBuilder.withNamespaceContext(uri2Prefix);
+    public CompareMatcher withNamespaceContext(Map<String, String> prefix2Uri) {
+        diffBuilder.withNamespaceContext(prefix2Uri);
         return this;
     }
 


### PR DESCRIPTION
Currently within the signature of DiffBuilder and CompareMatcher exists a typo : 

```
public DiffBuilder withNamespaceContext(Map<String, String> uri2Prefix)
```
which may very likely be misleading for new users of the library.
The mapping is between prefixes and URIs and not the other way arround (as expected by `Convet.toNamespaceContext(Map<String,String) prefix2Uri)` method

Issue : #61 