### PR TITLE
multiple code improvements: squid:S1197, squid:S1213, squid:S1854, squid:S1488, squid:S1118

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/input/CommentLessSource.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/input/CommentLessSource.java
@@ -25,6 +25,13 @@ import org.xmlunit.transform.Transformation;
  */
 public final class CommentLessSource extends DOMSource {
 
+    private static final String STYLE =
+            "<stylesheet version=\"1.0\" xmlns=\"http://www.w3.org/1999/XSL/Transform\">"
+            + "<template match=\"node()[not(self::comment())]|@*\"><copy>"
+            + "<apply-templates select=\"node()[not(self::comment())]|@*\"/>"
+            + "</copy></template>"
+            + "</stylesheet>";
+
     public CommentLessSource(Source originalSource) {
         super();
         if (originalSource == null) {
@@ -34,13 +41,6 @@ public final class CommentLessSource extends DOMSource {
         t.setStylesheet(getStylesheet());
         setNode(t.transformToDocument());
     }
-
-    private static final String STYLE =
-        "<stylesheet version=\"1.0\" xmlns=\"http://www.w3.org/1999/XSL/Transform\">"
-        + "<template match=\"node()[not(self::comment())]|@*\"><copy>"
-        + "<apply-templates select=\"node()[not(self::comment())]|@*\"/>"
-        + "</copy></template>"
-        + "</stylesheet>";
 
     private static Source getStylesheet() {
         return new StreamSource(new java.io.StringReader(STYLE));

--- a/xmlunit-core/src/main/java/org/xmlunit/transform/Transformation.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/transform/Transformation.java
@@ -167,7 +167,7 @@ public final class Transformation {
             if (fac == null) {
                 fac = TransformerFactory.newInstance();
             }
-            Transformer t = null;
+            Transformer t;
             if (styleSheet != null) {
                 t = fac.newTransformer(styleSheet);
             } else {

--- a/xmlunit-core/src/main/java/org/xmlunit/util/Convert.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/util/Convert.java
@@ -152,8 +152,7 @@ public final class Convert {
     private static Document tryExtractDocFromDOMSource(Source s) {
         Node n = tryExtractNodeFromDOMSource(s);
         if (n != null && n instanceof Document) {
-            @SuppressWarnings("unchecked") Document d = (Document) n;
-            return d;
+            return (Document)n;
         }
         return null;
     }

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/Languages.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/Languages.java
@@ -21,7 +21,6 @@ import javax.xml.XMLConstants;
  * environment.
  */
 public final class Languages {
-    private Languages() {}
 
     /**
      * W3C XML Schema. 
@@ -47,4 +46,6 @@ public final class Languages {
      * @see javax.xml.XMLConstants#RELAXNG_NS_URI
      */
     public static final String RELAXNG_NS_URI = XMLConstants.RELAXNG_NS_URI;
+
+    private Languages() {}
 }

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
@@ -133,6 +133,8 @@ public class ParsingValidator extends Validator {
 
         static final String SCHEMA_SOURCE =
             "http://java.sun.com/xml/jaxp/properties/schemaSource";
+
+        private Properties() {}
     }
 
     private class Handler extends DefaultHandler {

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/ValidationMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/ValidationMatcher.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
  */
 public class ValidationMatcher extends BaseMatcher {
 
-    private final Source schemaSource[];
+    private final Source[] schemaSource;
     private Source instance;
     private ValidationResult result;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 Array designators "[]" should be on the type, not the variable.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 Dead stores should be removed.
squid:S1488 Local Variables should not be declared and then immediately returned or thrown.
squid:S1118 Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1197
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1854
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava