### PR TITLE
Evaluate XPath Hamcrest Matcher

### DIFF
--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/EvaluateXPathMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/EvaluateXPathMatcher.java
@@ -1,0 +1,132 @@
+package org.xmlunit.matchers;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.util.Convert;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import javax.xml.transform.Source;
+import java.util.Map;
+
+/**
+ * This Hamcrest {@link Matcher} verifies whether the evaluation of the provided XPath expression
+ * corresponds to the value matcher specified for the provided input XML object.
+ * <p/>
+ * All types which are supported by {@link Input#from(Object)} can be used as input for the XML object
+ * against the matcher is evaluated.
+ * <p/>
+ * <b>Simple Example</b><br>
+ * <pre>
+ * final String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *
+ * assertThat(xml, hasXPath("//a/b/@attr", equalTo("abc")));
+ * assertThat(xml, hasXPath("count(//a/b/c)", equalTo("0")));
+ * </pre>
+ * <p/>
+ * <b>Example with namespace mapping</b>
+ * <pre>
+ *    String xml = &quot;&lt;?xml version=\&quot;1.0\&quot; encoding=\&quot;UTF-8\&quot;?&gt;&quot; +
+ *          &quot;&lt;feed xmlns=\&quot;http://www.w3.org/2005/Atom\&quot;&gt;&quot; +
+ *          &quot;   &lt;title&gt;title&lt;/title&gt;&quot; +
+ *          &quot;   &lt;entry&gt;&quot; +
+ *          &quot;       &lt;title&gt;title1&lt;/title&gt;&quot; +
+ *          &quot;       &lt;id&gt;id1&lt;/id&gt;&quot; +
+ *          &quot;   &lt;/entry&gt;&quot; +
+ *          &quot;&lt;/feed&gt;&quot;;
+ *
+ *    HashMap&lt;String, String&gt; prefix2Uri = new HashMap&lt;String, String&gt;();
+ *    prefix2Uri.put(&quot;atom&quot;, &quot;http://www.w3.org/2005/Atom&quot;);
+ *    assertThat(xmlRootElement,
+ *          hasXPath(&quot;//atom:feed/atom:entry/atom:id/text()&quot;, equalTo(&quot;id1&quot;))
+ *          .withNamespaceContext(prefix2Uri));
+ * </pre>
+ *
+ * @since XMLUnit 2.1.0
+ */
+public class EvaluateXPathMatcher extends BaseMatcher<Object> {
+    private final String xPath;
+    private final Matcher<String> valueMatcher;
+    private Map<String, String> prefix2Uri;
+
+    /**
+     * Creates a {@link EvaluateXPathMatcher} instance with the associated XPath expression and
+     * the value matcher corresponding to the XPath evaluation.
+     *
+     * @param xPath        xPath expression
+     * @param valueMatcher matcher for the value at the specified xpath
+     */
+    public EvaluateXPathMatcher(String xPath, Matcher<String> valueMatcher) {
+        this.xPath = xPath;
+        this.valueMatcher = valueMatcher;
+    }
+
+    /**
+     * Creates a matcher that matches when the examined XML input has a value at the
+     * specified <code>xPath</code> that satisfies the specified <code>valueMatcher</code>.
+     * <p/>
+     * For example:
+     * <pre>assertThat(xml, hasXPath(&quot;//fruits/fruit/@name&quot;, equalTo(&quot;apple&quot;))</pre>
+     *
+     * @param xPath the target xpath
+     * @param valueMatcher matcher for the value at the specified xpath
+     * @return the xpath matcher
+     */
+    @Factory
+    public static EvaluateXPathMatcher hasXPath(String xPath, Matcher<String> valueMatcher) {
+        return new EvaluateXPathMatcher(xPath, valueMatcher);
+    }
+
+    @Override
+    public boolean matches(Object object) {
+        String value = xPathEvaluate(object);
+        return valueMatcher.matches(value);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("XML with XPath ").appendText(xPath);
+        if (valueMatcher != null) {
+            description.appendText(" evaluated to ").appendDescriptionOf(valueMatcher);
+        }
+    }
+
+    @Override
+    public void describeMismatch(Object object, Description mismatchDescription) {
+        if (valueMatcher != null) {
+            String value = xPathEvaluate(object);
+            valueMatcher.describeMismatch(value, mismatchDescription);
+        }
+    }
+
+    /**
+     * Utility method used for creating a namespace context mapping to be used in XPath matching.
+     *
+     * @param prefix2Uri prefix2Uri maps from prefix to namespace URI. It is used to resolve
+     *                   XML namespace prefixes in the XPath expression
+     * @since XMLUnit 2.0.1
+     */
+    public EvaluateXPathMatcher withNamespaceContext(Map<String, String> prefix2Uri) {
+        this.prefix2Uri = prefix2Uri;
+        return this;
+    }
+
+    /**
+     * Evaluates the provided XML input to the configured <code>xPath</code> field XPath expression.
+     * @param input an XML input
+     * @return the result of the XPath evaluation
+     */
+    private String xPathEvaluate(Object input) {
+        JAXPXPathEngine engine = new JAXPXPathEngine();
+        if (prefix2Uri != null) {
+            engine.setNamespaceContext(prefix2Uri);
+        }
+
+        Source s = Input.from(input).build();
+        Node n = Convert.toNode(s);
+        return engine.evaluate(xPath, n);
+    }
+}

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/EvaluateXPathMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/EvaluateXPathMatcherTest.java
@@ -1,0 +1,86 @@
+package org.xmlunit.matchers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+public class EvaluateXPathMatcherTest {
+
+    @Test
+    public void testXPathCountInXmlString() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                    "<fruit name=\"apple\"/>" +
+                    "<fruit name=\"orange\"/>" +
+                    "<fruit name=\"banana\"/>" +
+                "</fruits>";
+        assertThat(xml, hasXPath("count(//fruits/fruit)", equalTo("3")));
+        assertThat(xml, hasXPath("//fruits/fruit/@name", equalTo("apple")));
+        assertThat(xml, hasXPath("count(//fruits/fruit[@name=\"orange\"])", equalTo("1")));
+        assertThat(xml, hasXPath("count(//fruits/fruit[@name=\"apricot\"])", equalTo("0")));
+    }
+
+    @Test
+    public void testXPathAttributeValueMatchingInXmlString() throws Exception {
+        String xml = "<a><b attr=\"abc\"></b></a>";
+        assertThat(xml, hasXPath("//a/b/@attr", equalTo("abc")));
+        assertThat(xml, hasXPath("count(//a/b/c)", equalTo("0")));
+
+
+        try {
+            assertThat(xml, hasXPath("//a/b/@attr", equalTo("something")));
+            Assert.fail("Should throw AssertionError");
+        }catch(AssertionError e){
+            assertThat(e.getMessage(), containsString("was \"abc\""));
+        }
+
+    }
+
+    @Test
+    public void testXPathAttributeValueMatchingInXmlElement() throws Exception {
+        String xml = "<a><b attr=\"abc\"></b></a>";
+        DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
+        f.setNamespaceAware(true);
+        DocumentBuilder db = f.newDocumentBuilder();
+        Element xmlRootElement = db.parse(
+                new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8")))).getDocumentElement();
+        assertThat(xmlRootElement, hasXPath("//a/b/@attr", equalTo("abc")));
+    }
+
+    @Test
+    public void testXPathEvaluationWithNamespaceContext() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<feed xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "   <title>Search Engine Feed</title>" +
+                "   <link href=\"https://en.wikipedia.org/wiki/Web_search_engine\"/>" +
+                "   <entry>" +
+                "       <title>Google</title>" +
+                "       <id>goog</id>" +
+                "   </entry>" +
+                "   <entry>" +
+                "       <title>Bing</title>" +
+                "       <id>msft</id>" +
+                "   </entry>" +
+                "</feed>";
+
+        HashMap<String, String> prefix2Uri = new HashMap<String, String>();
+        prefix2Uri.put("atom", "http://www.w3.org/2005/Atom");
+
+        assertThat(xml, hasXPath("count(//atom:feed/atom:entry)", equalTo("2")).withNamespaceContext(prefix2Uri));
+        assertThat(xml, hasXPath("//atom:feed/atom:entry/atom:title/text()",
+                equalTo("Google")).withNamespaceContext(prefix2Uri));
+        assertThat(xml, hasXPath("//atom:feed/atom:entry[2]/atom:title/text()",
+                equalTo("Bing")).withNamespaceContext(prefix2Uri));
+    }
+}


### PR DESCRIPTION
Added hamcrest Matcher to verify whether the evaluation of the  XPath expression specified corresponds to the specified value matcher in provided xml input.

Design of this matcher is similar to org.hamcrest.xml.HasXPath matcher, but it provides the ability to match not only org.w3c.dom.Node instance, but instead anything supported by org.xmlunit.build.Input.from(Object)