### PR TITLE
multiple code improvements: squid:S1192, squid:SwitchLastCaseIsDefaultCheck, squid:S1213, squid:S00122, squid:UselessParenthesesCheck

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
@@ -105,7 +105,7 @@ public class Input {
         if (object instanceof Source) {
             xml = new SourceHoldingBuilder((Source) object);
         } else if (object instanceof Builder) {
-            xml = ((Builder) object);
+            xml = (Builder) object;
         } else if (object instanceof Document) {
             xml = Input.fromDocument((Document) object);
         } else if (object instanceof Node) {

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/AbstractDifferenceEngine.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/AbstractDifferenceEngine.java
@@ -24,6 +24,8 @@ import org.xmlunit.util.Predicate;
  * interface.
  */
 public abstract class AbstractDifferenceEngine implements DifferenceEngine {
+    private static final String NOT_BE_NULL = " not be null";
+    private static final String LISTENER_MUST_NOT_BE_NULL = "listener must not be null";
     private final ComparisonListenerSupport listeners =
         new ComparisonListenerSupport();
     private NodeMatcher nodeMatcher = new DefaultNodeMatcher();
@@ -43,7 +45,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     @Override
     public void addComparisonListener(ComparisonListener l) {
         if (l == null) {
-            throw new IllegalArgumentException("listener must not be null");
+            throw new IllegalArgumentException(LISTENER_MUST_NOT_BE_NULL);
         }
         listeners.addComparisonListener(l);
     }
@@ -51,7 +53,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     @Override
     public void addMatchListener(ComparisonListener l) {
         if (l == null) {
-            throw new IllegalArgumentException("listener must not be null");
+            throw new IllegalArgumentException(LISTENER_MUST_NOT_BE_NULL);
         }
         listeners.addMatchListener(l);
     }
@@ -59,7 +61,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     @Override
     public void addDifferenceListener(ComparisonListener l) {
         if (l == null) {
-            throw new IllegalArgumentException("listener must not be null");
+            throw new IllegalArgumentException(LISTENER_MUST_NOT_BE_NULL);
         }
         listeners.addDifferenceListener(l);
     }
@@ -68,7 +70,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     public void setNodeMatcher(NodeMatcher n) {
         if (n == null) {
             throw new IllegalArgumentException("node matcher must"
-                                               + " not be null");
+                                               + NOT_BE_NULL);
         }
         nodeMatcher = n;
     }
@@ -84,7 +86,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     public void setDifferenceEvaluator(DifferenceEvaluator e) {
         if (e == null) {
             throw new IllegalArgumentException("difference evaluator must"
-                                               + " not be null");
+                                               + NOT_BE_NULL);
         }
         diffEvaluator = e;
     }
@@ -100,7 +102,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     public void setComparisonController(ComparisonController c) {
         if (c == null) {
             throw new IllegalArgumentException("comparison controller must"
-                                               + " not be null");
+                                               + NOT_BE_NULL);
         }
         comparisonController = c;
     }
@@ -128,7 +130,7 @@ public abstract class AbstractDifferenceEngine implements DifferenceEngine {
     public void setAttributeFilter(Predicate<Attr> af) {
         if (af == null) {
             throw new IllegalArgumentException("attribute filter must"
-                                               + " not be null");
+                                               + NOT_BE_NULL);
         }
         this.attributeFilter = af;
     }

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/DOMDifferenceEngine.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/DOMDifferenceEngine.java
@@ -44,6 +44,15 @@ import org.w3c.dom.ProcessingInstruction;
  */
 public final class DOMDifferenceEngine extends AbstractDifferenceEngine {
 
+    /**
+     * Maps Nodes to their QNames.
+     */
+    private static final Mapper<Node, QName> QNAME_MAPPER =
+        new Mapper<Node, QName>() {
+            @Override
+            public QName apply(Node n) { return Nodes.getQName(n); }
+        };
+
     @Override
     public void compare(Source control, Source test) {
         if (control == null) {
@@ -174,6 +183,8 @@ public final class DOMDifferenceEngine extends AbstractDifferenceEngine {
                 return compareAttributes((Attr) control, controlContext,
                                          (Attr) test, testContext);
             }
+            break;
+        default:
             break;
         }
         return new OngoingComparisonState();
@@ -795,14 +806,5 @@ public final class DOMDifferenceEngine extends AbstractDifferenceEngine {
         }
         return null;
     }
-
-    /**
-     * Maps Nodes to their QNames.
-     */
-    private static final Mapper<Node, QName> QNAME_MAPPER =
-        new Mapper<Node, QName>() {
-            @Override
-            public QName apply(Node n) { return Nodes.getQName(n); }
-        };
 
 }

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/MultiLevelByNameAndTextSelector.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/MultiLevelByNameAndTextSelector.java
@@ -100,7 +100,9 @@ public class MultiLevelByNameAndTextSelector implements ElementSelector {
         if (ignoreEmptyTexts) {
             while (isText(n1) && n1.getNodeValue().trim().length() == 0) {
                 Node n2 = n1.getNextSibling();
-                if (n2 == null) break;
+                if (n2 == null) {
+                    break;
+                }
                 n1 = n2;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 String literals should not be duplicated.
squid:SwitchLastCaseIsDefaultCheck "switch" statements should end with a "default" clause.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:S00122 Statements should be on separate lines.
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ASwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava