### PR TITLE
multiple code improvements: squid:SwitchLastCaseIsDefaultCheck. squidS1213, squid:S1854

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/diff/DefaultNodeMatcher.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/DefaultNodeMatcher.java
@@ -51,6 +51,8 @@ import org.w3c.dom.Node;
  * e1} alone.</p>
  */
 public class DefaultNodeMatcher implements NodeMatcher {
+    private static final short CDATA = Node.TEXT_NODE;
+    private static final short TEXT = Node.CDATA_SECTION_NODE;
     private final ElementSelector[] elementSelectors;
     private final NodeTypeMatcher nodeTypeMatcher;
 
@@ -182,9 +184,6 @@ public class DefaultNodeMatcher implements NodeMatcher {
          */
         boolean canBeCompared(short controlType, short testType);
     }
-
-    private static final short CDATA = Node.TEXT_NODE;
-    private static final short TEXT = Node.CDATA_SECTION_NODE;
 
     /**
      * {@link NodeTypeMatcher} that marks pairs of nodes of the same

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
@@ -22,7 +22,6 @@ import org.w3c.dom.Node;
  * Evaluators used for the base cases.
  */
 public final class DifferenceEvaluators {
-    private DifferenceEvaluators() { }
 
     private static final Short CDATA = Node.CDATA_SECTION_NODE;
     private static final Short TEXT = Node.TEXT_NODE;
@@ -72,11 +71,15 @@ public final class DifferenceEvaluators {
                     case XML_ENCODING:
                         outcome = ComparisonResult.SIMILAR;
                         break;
+                    default:
+                        break;
                     }
                 }
                 return outcome;
             }
         };
+
+    private DifferenceEvaluators() { }
 
     /**
      * Combines multiple DifferenceEvaluators so that the first one

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/NodeFilters.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/NodeFilters.java
@@ -20,7 +20,6 @@ import org.xmlunit.util.Predicate;
  * Common NodeFilter implementations.
  */
 public final class NodeFilters {
-    private NodeFilters() { }
 
     /**
      * Suppresses document-type and XML declaration nodes.
@@ -31,4 +30,6 @@ public final class NodeFilters {
                 return n.getNodeType() != Node.DOCUMENT_TYPE_NODE;
             }
         };
+
+    private NodeFilters() { }
 }

--- a/xmlunit-core/src/main/java/org/xmlunit/diff/XPathContext.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/XPathContext.java
@@ -163,7 +163,7 @@ public class XPathContext implements Cloneable {
         }
 
         for (NodeInfo child : children) {
-            Level l = null;
+            Level l;
             switch (child.getType()) {
             case Node.COMMENT_NODE:
                 l = new Level(COMMENT + OPEN + (++comments) + CLOSE);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck "switch" statements should end with a "default" clause.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 Dead stores should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ASwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1854
Please let me know if you have any questions.
George Kankava