### PR TITLE
multiple code improvements: squid:S1193, squid:S2272, squid:S1213

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/util/IterableNodeList.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/util/IterableNodeList.java
@@ -15,6 +15,8 @@ package org.xmlunit.util;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -41,6 +43,9 @@ public final class IterableNodeList implements Iterable<Node> {
             throw new UnsupportedOperationException();
         }
         public Node next() {
+            if(!hasNext()) {
+                throw new NoSuchElementException();
+            } 
             return nl.item(current++);
         }
         public boolean hasNext() {

--- a/xmlunit-core/src/main/java/org/xmlunit/util/Nodes.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/util/Nodes.java
@@ -31,6 +31,8 @@ import org.w3c.dom.Text;
  * Utility algorithms that work on DOM nodes.
  */
 public final class Nodes {
+    private static final char SPACE = ' ';
+
     private Nodes() { }
 
     /**
@@ -145,8 +147,6 @@ public final class Nodes {
             }
         }
     }
-
-    private static final char SPACE = ' ';
 
     /**
      * Normalize a string.

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/JAXPValidator.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/JAXPValidator.java
@@ -53,12 +53,10 @@ public class JAXPValidator extends Validator {
         f.setErrorHandler(v);
         try {
             f.newSchema(getSchemaSources());
+        } catch (SAXParseException e) {
+            v.error((SAXParseException) e);
         } catch (SAXException e) {
-            if (e instanceof SAXParseException) {
-                v.error((SAXParseException) e);
-            } else {
                 throw new XMLUnitException(e);
-            }
         } finally {
             f.setErrorHandler(null);
         }
@@ -77,12 +75,10 @@ public class JAXPValidator extends Validator {
         val.setErrorHandler(v);
         try {
             val.validate(s);
+        } catch (SAXParseException e) {
+            v.error((SAXParseException) e);
         } catch (SAXException e) {
-            if (e instanceof SAXParseException) {
-                v.error((SAXParseException) e);
-            } else {
                 throw new XMLUnitException(e);
-            }
         } catch (java.io.IOException e) {
             throw new XMLUnitException(e);
         }

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
@@ -106,12 +106,10 @@ public class ParsingValidator extends Validator {
             InputSource input = Convert.toInputSource(s);
             try {
                 parser.parse(input, handler);
+            } catch (SAXParseException e) {
+                handler.error((SAXParseException) e);
             } catch (SAXException e) {
-                if (e instanceof SAXParseException) {
-                    handler.error((SAXParseException) e);
-                } else {
-                    throw new XMLUnitException(e);
-                }
+                throw new XMLUnitException(e);
             }
             return handler.getResult();
         } catch (ParserConfigurationException ex) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1193 Exception types should not be tested using "instanceof" in catch blocks.
squid:S2272 "Iterator.next()" methods should throw "NoSuchElementException".
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1193
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2272
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava