### PR TITLE
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Diff.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Diff.java
@@ -77,7 +77,7 @@ public class Diff
     private boolean identical = true;
     private boolean compared = false;
     private boolean haltComparison = false;
-    private StringBuffer messages;
+    private StringBuilder messages;
     private DifferenceEngineContract differenceEngine;
     private DifferenceListener  differenceListenerDelegate;
     private ElementQualifier elementQualifierDelegate;
@@ -153,7 +153,7 @@ public class Diff
         this.testDoc = getManipulatedDocument(testDoc);
         this.elementQualifierDelegate = elementQualifier;
         this.differenceEngine = comparator;
-        this.messages = new StringBuffer();
+        this.messages = new StringBuilder();
     }
 
     /**
@@ -265,7 +265,7 @@ public class Diff
      * @param appendTo the messages buffer
      * @param difference
      */
-    private void appendDifference(StringBuffer appendTo, Difference difference) {
+    private void appendDifference(StringBuilder appendTo, Difference difference) {
         appendTo.append(' ').append(difference).append('\n');
     }
 

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeReader.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeReader.java
@@ -121,7 +121,7 @@ public class DoctypeReader extends Reader {
      *  stream has been reached
      * @throws IOException
      */
-    public int read(char cbuf[], int off, int len) throws IOException {
+    public int read(char[] cbuf, int off, int len) throws IOException {
         int startPos = off;
         int currentlyRead;
         while (off - startPos < len && (currentlyRead = read()) != -1) {

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/TolerantSaxDocumentBuilder.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/TolerantSaxDocumentBuilder.java
@@ -66,7 +66,7 @@ import org.xml.sax.helpers.DefaultHandler;
 public class TolerantSaxDocumentBuilder
     extends DefaultHandler implements LexicalHandler {
     private final DocumentBuilder documentBuilder;
-    private final StringBuffer traceBuffer;
+    private final StringBuilder traceBuilder;
     private Document currentDocument;
     private Element currentElement;
 
@@ -79,7 +79,7 @@ public class TolerantSaxDocumentBuilder
     public TolerantSaxDocumentBuilder(DocumentBuilder documentBuilder)
         throws ParserConfigurationException {
         this.documentBuilder = documentBuilder;
-        this.traceBuffer = new StringBuffer();
+        this.traceBuilder = new StringBuilder();
     }
 
     /**
@@ -93,7 +93,7 @@ public class TolerantSaxDocumentBuilder
      * @return the trace of Sax calls that were used to build up the Document
      */
     public String getTrace() {
-        return traceBuffer.toString();
+        return traceBuilder.toString();
     }
 
     /**
@@ -101,7 +101,7 @@ public class TolerantSaxDocumentBuilder
      * @throws SAXException
      */
     public void startDocument() throws SAXException {
-        traceBuffer.delete(0, traceBuffer.length());
+        traceBuilder.delete(0, traceBuilder.length());
         trace("startDocument");
         currentDocument = documentBuilder.newDocument();
         currentElement = null;
@@ -184,7 +184,7 @@ public class TolerantSaxDocumentBuilder
         }
     }
 
-    private boolean isElementMatching(Element anElement, String qname) {
+    private static boolean isElementMatching(Element anElement, String qname) {
         return anElement.getNodeName()!=null
             && anElement.getNodeName().equals(qname);
     }
@@ -201,7 +201,7 @@ public class TolerantSaxDocumentBuilder
      * Unhandled ContentHandler method
      * @throws SAXException
      */
-    public void ignorableWhitespace (char ch[], int start, int length)
+    public void ignorableWhitespace (char[] ch, int start, int length)
         throws SAXException {
         unhandled("ignorableWhitespace");
     }
@@ -301,7 +301,7 @@ public class TolerantSaxDocumentBuilder
      * LexicalHandler method
      * @throws SAXException
      */
-    public void comment(char ch[], int start, int length)
+    public void comment(char[] ch, int start, int length)
         throws SAXException     {
         String commentText = new String(ch, start, length);
         trace("comment:" + commentText);
@@ -331,7 +331,7 @@ public class TolerantSaxDocumentBuilder
      * @param method
      */
     private void trace(String method) {
-        traceBuffer.append(method).append('\n');
+        traceBuilder.append(method).append('\n');
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
Please let me know if you have any questions.
George Kankava