### PR TITLE
multiple code improvements: squid:S1149, squid:S00122, squid:UselessParenthesesCheck

### DIFF
--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Validator.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/Validator.java
@@ -81,7 +81,7 @@ import javax.xml.transform.stream.StreamSource;
  */
 public class Validator extends DefaultHandler {
     private final InputSource validationInputSource;
-    private final StringBuffer messages;
+    private final StringBuilder messages;
     private final boolean usingDoctypeReader;
     private final String systemId;
 
@@ -101,7 +101,7 @@ public class Validator extends DefaultHandler {
                         String systemId,
                         boolean usingDoctypeReader) {
         isValid = null;
-        messages = new StringBuffer();
+        messages = new StringBuilder();
         this.validationInputSource = inputSource;
         this.systemId = systemId;
         this.usingDoctypeReader = usingDoctypeReader;
@@ -169,7 +169,7 @@ public class Validator extends DefaultHandler {
      */
     public Validator(Reader readerForValidation, String systemID) {
         this(new InputSource(readerForValidation), systemID,
-             (readerForValidation instanceof DoctypeReader));
+             readerForValidation instanceof DoctypeReader);
     }
 
     /**
@@ -289,7 +289,7 @@ public class Validator extends DefaultHandler {
      * @param toAppendTo
      * @return specified StringBuffer with message(s) appended
      */
-    private StringBuffer appendMessage(StringBuffer toAppendTo) {
+    private StringBuilder appendMessage(StringBuilder toAppendTo) {
         if (isValid()) {
             return toAppendTo.append("[valid]");
         }
@@ -300,8 +300,8 @@ public class Validator extends DefaultHandler {
      * @return class name appended with validation messages
      */
     public String toString() {
-        StringBuffer buf = new StringBuffer(super.toString()).append(':');
-        return appendMessage(buf).toString();
+        StringBuilder builder = new StringBuilder(super.toString()).append(':');
+        return appendMessage(builder).toString();
     }
 
     /**
@@ -348,7 +348,9 @@ public class Validator extends DefaultHandler {
     private void validationProblem(ValidationProblem p) {
         String msg = "At line " + p.getLine() + ", column: "
             + p.getColumn() + " ==> " + p.getMessage();
-        if (!msg.endsWith("\n")) msg += "\n";
+        if (!msg.endsWith("\n")) { 
+            msg += "\n";
+        }
         invalidate(msg);
     }
 

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XMLAssert.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/XMLAssert.java
@@ -131,7 +131,7 @@ public class XMLAssert extends Assert implements XSLTConstants {
     }
 
     private static String getFailMessage(String msg, Diff diff) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (msg != null && msg.length() > 0) {
             sb.append(msg).append(", ");
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S00122 Statements should be on separate lines.
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava