### PR TITLE
multiple code improvements: squid:S1118, squid:S1213

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/DifferenceEvaluators.java
@@ -82,6 +82,8 @@ public final class DifferenceEvaluators {
             }
         };
 
+    private DifferenceEvaluators() {}
+
     /**
      * Combines multiple DifferenceEvaluators so that the first one
      * that changes the outcome wins.
@@ -248,7 +250,5 @@ public final class DifferenceEvaluators {
             && comparison.getControlDetails().getTarget() instanceof Element
             && comparison.getControlDetails().getTarget().getParentNode() instanceof Document;
     }
-
-    private DifferenceEvaluators() { }
 
 }

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/JAXPConstants.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/JAXPConstants.java
@@ -48,6 +48,9 @@ public final class JAXPConstants {
      * {@link XMLReader#setProperty(String, Object)}.
      * 
      */
+
+    private JAXPConstants() { }
+
     public static final class Properties {
 
         /**
@@ -66,5 +69,6 @@ public final class JAXPConstants {
          */
         public static final String SCHEMA_SOURCE = "http://java.sun.com/xml/jaxp/properties/schemaSource";
 
+        private Properties() { }
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 Utility classes should not have public constructors.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava