### PR TITLE
multiple code improvements: squid:S1149, squid:ModifiersOrderCheck

### DIFF
--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeReader.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeReader.java
@@ -51,7 +51,7 @@ import java.io.Reader;
 public class DoctypeReader extends Reader {
 
     private final BufferedReader originalReader;
-    private final StringBuffer sourceBuffer = new StringBuffer(1024);
+    private final StringBuilder sourceBuilder = new StringBuilder(1024);
 
     private final DoctypeSupport support;
 
@@ -91,9 +91,9 @@ public class DoctypeReader extends Reader {
      * @return the contents of the originalSource within a StringBuffer
      * @throws IOException if thrown while reading from the original source
      */
-    private StringBuffer getContent(BufferedReader originalSource)
+    private StringBuilder getContent(BufferedReader originalSource)
         throws IOException {
-        if (sourceBuffer.length() == 0) {
+        if (sourceBuilder.length() == 0) {
             String newline = System.getProperty("line.separator");
             String source;
             boolean atFirstLine = true;
@@ -101,15 +101,15 @@ public class DoctypeReader extends Reader {
                 if (atFirstLine) {
                     atFirstLine = false;
                 } else {
-                    sourceBuffer.append(newline);
+                    sourceBuilder.append(newline);
                 }
-                sourceBuffer.append(source);
+                sourceBuilder.append(source);
             }
 
             originalSource.close();
         }
 
-        return sourceBuffer;
+        return sourceBuilder;
     }
 
     /**

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeSupport.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/DoctypeSupport.java
@@ -53,11 +53,11 @@ final class DoctypeSupport {
         int read() throws IOException;
     }
 
-    final static String DOCTYPE_OPEN_DECL = "<!";
-    final static String DOCTYPE_CLOSE_DECL = ">";
-    final static String DOCTYPE = "DOCTYPE ";
-    final static String SYSTEM = " SYSTEM \"";
-    private final static int[] DOCTYPE_INTS = {
+    static final String DOCTYPE_OPEN_DECL = "<!";
+    static final String DOCTYPE_CLOSE_DECL = ">";
+    static final String DOCTYPE = "DOCTYPE ";
+    static final String SYSTEM = " SYSTEM \"";
+    private static final int[] DOCTYPE_INTS = {
         'D', 'O', 'C', 'T', 'Y', 'P', 'E', ' '
     };
 
@@ -74,7 +74,7 @@ final class DoctypeSupport {
                    boolean characters, String encoding) {
         this.original = original;
 
-        StringBuffer sb = new StringBuffer(DOCTYPE_OPEN_DECL);
+        StringBuilder sb = new StringBuilder(DOCTYPE_OPEN_DECL);
         sb.append(DOCTYPE).append(name).append(SYSTEM)
             .append(systemId).append('\"').append(DOCTYPE_CLOSE_DECL);
         String s = sb.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:ModifiersOrderCheck Modifiers should be declared in the correct order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AModifiersOrderCheck
Please let me know if you have any questions.
George Kankava