### PR TITLE
multiple code improvements: squid:S1186, squid:S1149

### DIFF
--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/HTMLDocumentBuilder.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/HTMLDocumentBuilder.java
@@ -63,7 +63,7 @@ import org.xml.sax.helpers.AttributesImpl;
 public class HTMLDocumentBuilder {
     protected final TolerantSaxDocumentBuilder tolerantSaxDocumentBuilder;
     protected final SwingEvent2SaxAdapter swingEvent2SaxAdapter;
-    private final StringBuffer traceBuffer;
+    private final StringBuilder traceBuilder;
 
     /**
      * Constructor
@@ -74,7 +74,7 @@ public class HTMLDocumentBuilder {
                                TolerantSaxDocumentBuilder tolerantSaxDocumentBuilder) {
         this.tolerantSaxDocumentBuilder = tolerantSaxDocumentBuilder;
         this.swingEvent2SaxAdapter = new SwingEvent2SaxAdapter();
-        this.traceBuffer = new StringBuffer();
+        this.traceBuilder = new StringBuilder();
     }
 
     /**
@@ -84,9 +84,9 @@ public class HTMLDocumentBuilder {
      * @see TolerantSaxDocumentBuilder
      */
     public Document parse(Reader reader) throws SAXException, IOException {
-        traceBuffer.delete(0, traceBuffer.length());
+        traceBuilder.delete(0, traceBuilder.length());
         swingEvent2SaxAdapter.parse(reader, tolerantSaxDocumentBuilder);
-        traceBuffer.append(tolerantSaxDocumentBuilder.getTrace());
+        traceBuilder.append(tolerantSaxDocumentBuilder.getTrace());
         return tolerantSaxDocumentBuilder.getDocument();
     }
 
@@ -104,7 +104,7 @@ public class HTMLDocumentBuilder {
      * @return the trace of events and / or warnings encountered during parsing
      */
     public String getTrace() {
-        return traceBuffer.toString();
+        return traceBuilder.toString();
     }
 
     /**
@@ -112,7 +112,7 @@ public class HTMLDocumentBuilder {
      * @param msg what to append
      */
     private void trace(String msg) {
-        traceBuffer.append(msg).append('\n');
+        traceBuilder.append(msg).append('\n');
     }
 
     /**
@@ -175,6 +175,7 @@ public class HTMLDocumentBuilder {
          * Swing-HTML-parser template method, no ContentHandler equivalent
          */
         public void flush() throws BadLocationException {
+            throw new UnsupportedOperationException();
         }
 
         /**

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/NodeTestException.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/NodeTestException.java
@@ -81,11 +81,11 @@ public class NodeTestException extends Exception {
      * @return the exception message and node information if available
      */
     public String getMessage() {
-        StringBuffer stringBuffer = new StringBuffer(super.getMessage());
+        StringBuilder stringBuilder = new StringBuilder(super.getMessage());
         if (hasNode()) {
-            stringBuffer.append(' ')
+            stringBuilder.append(' ')
                 .append(getNode().toString());
         }
-        return stringBuffer.toString();
+        return stringBuilder.toString();
     }
 }

--- a/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/SimpleXpathEngine.java
+++ b/xmlunit-legacy/src/main/java/org/custommonkey/xmlunit/SimpleXpathEngine.java
@@ -71,8 +71,8 @@ public class SimpleXpathEngine implements XpathEngine, XSLTConstants {
     /**
      * What every XSL transform needs
      */
-    private StringBuffer getXSLTBase() {
-        StringBuffer result = new StringBuffer(XML_DECLARATION)
+    private StringBuilder getXSLTBase() {
+        StringBuilder result = new StringBuilder(XML_DECLARATION)
             .append(XMLUnit.getXSLTStart());
         String tmp = result.toString();
         int close = tmp.lastIndexOf('>');
@@ -239,7 +239,7 @@ public class SimpleXpathEngine implements XpathEngine, XSLTConstants {
      * current context.
      */
     private String getNamespaceDeclarations() {
-        StringBuffer nsDecls = new StringBuffer();
+        StringBuilder nsDecls = new StringBuilder();
         String quoteStyle = "'";
         for (Iterator keys = ctx.getPrefixes(); keys.hasNext(); ) {
             String prefix = (String) keys.next();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1186 Methods should not be empty.
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1186
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
Please let me know if you have any questions.
George Kankava