### PR TITLE
Make travis builds for java6 work again (fixes #100)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
 language: java
 jdk:
+  - openjdk6
   - openjdk7
   - oraclejdk8
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+# use java 6 compatible maven version
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip
+  - unzip -qq apache-maven-3.2.5-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.2.5
+  - export PATH=$M2_HOME/bin:$PATH
 install: true
 notifications:
   email:


### PR DESCRIPTION
Install open-jdk6, as it was removed from the default image.

Install java 6 compatible maven version.

It is possible that their is a better solution using docker, so feel free to reject.