### PR TITLE
Make travis builds for java6 work again (fixes #100)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,7 @@ jdk:
   - openjdk6
   - openjdk7
   - oraclejdk8
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-# use java 6 compatible maven version
-before_install:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip
-  - unzip -qq apache-maven-3.2.5-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.2.5
-  - export PATH=$M2_HOME/bin:$PATH
-install: true
+dist: precise
 notifications:
   email:
     - xmlunit-commits@lists.sourceforge.net


### PR DESCRIPTION
Fall-back to precise distribution instead of installing openjdk6 and maven 3.2.5

A less hacky/verbose solution, but I do not know how future proof it is.

According to https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming 

`We have no immediate plans to discontinue support for jobs that specify sudo: required and dist: precise, although we do not plan to update the images for these jobs any more.`

So feel free to keep the old fix. :-)