### PR TITLE
Enhancements of assertj module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ String content = xpath.evaluate("/foo/text()", source);
 assert "bar".equals(content);
 ```
 
-or using `HasXPathMatcher` and `EvaluateXPathMatcher`
+or using `HasXPathMatcher`, `EvaluateXPathMatcher` and `XmlAssert`
 
 ```java
 assertThat("<foo>bar</foo>", HasXPathMatcher.hasXPath("/foo"));
 assertThat("<foo>bar</foo>", EvaluateXPathMatcher.hasXPath("/foo/text()",
                                                            equalTo("bar")));
+XmlAssert.assertThat("<foo>bar</foo>").hasXPath("/foo");
 ```
 
 ### Validating a Document Against an XML Schema

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
@@ -13,7 +13,6 @@
 */
 package org.xmlunit.assertj;
 
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.FactoryBasedNavigableIterableAssert;
 import org.w3c.dom.Node;
 import org.xmlunit.builder.Input;
@@ -35,6 +34,7 @@ import javax.xml.transform.Source;
  *
  * assertThat(xml).nodesByXPath("//a/b").haveAttribute("attr").
  * </pre>
+ *
  * @since XMLUnit 2.6.1
  */
 public class MultipleNodeAssert extends FactoryBasedNavigableIterableAssert<MultipleNodeAssert, Iterable<Node>, Node, SingleNodeAssert> {
@@ -48,8 +48,6 @@ public class MultipleNodeAssert extends FactoryBasedNavigableIterableAssert<Mult
     }
 
     static MultipleNodeAssert create(Object xmlSource, XPathEngine xPathEngine, DocumentBuilderFactory dbf, String xPath) {
-
-        Assertions.assertThat(xPath).isNotBlank();
 
         Source s = Input.from(xmlSource).build();
         Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
@@ -62,7 +62,8 @@ public class MultipleNodeAssert extends FactoryBasedNavigableIterableAssert<Mult
         Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);
         Iterable<Node> nodes = engine.selectNodes(xPath, root);
 
-        return new MultipleNodeAssert(nodes);
+        return new MultipleNodeAssert(nodes)
+                .describedAs("XPath \"%s\" evaluated to node set", xPath);
     }
 
     /**

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
@@ -13,14 +13,16 @@
 */
 package org.xmlunit.assertj;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.FactoryBasedNavigableIterableAssert;
 import org.w3c.dom.Node;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
-import org.xmlunit.xpath.XPathEngine;
+import org.xmlunit.xpath.JAXPXPathEngine;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
+import java.util.Map;
 
 /**
  * Assertion methods for {@link Iterable} of {@link Node}.
@@ -47,11 +49,18 @@ public class MultipleNodeAssert extends FactoryBasedNavigableIterableAssert<Mult
         super(nodes, MultipleNodeAssert.class, new NodeAssertFactory());
     }
 
-    static MultipleNodeAssert create(Object xmlSource, XPathEngine xPathEngine, DocumentBuilderFactory dbf, String xPath) {
+    static MultipleNodeAssert create(Object xmlSource, Map<String, String> prefix2Uri, DocumentBuilderFactory dbf, String xPath) {
+
+        Assertions.assertThat(xPath).isNotBlank();
+
+        final JAXPXPathEngine engine = new JAXPXPathEngine();
+        if (prefix2Uri != null) {
+            engine.setNamespaceContext(prefix2Uri);
+        }
 
         Source s = Input.from(xmlSource).build();
         Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);
-        Iterable<Node> nodes = xPathEngine.selectNodes(xPath, root);
+        Iterable<Node> nodes = engine.selectNodes(xPath, root);
 
         return new MultipleNodeAssert(nodes);
     }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/MultipleNodeAssert.java
@@ -13,8 +13,15 @@
 */
 package org.xmlunit.assertj;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.FactoryBasedNavigableIterableAssert;
 import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.util.Convert;
+import org.xmlunit.xpath.XPathEngine;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Source;
 
 /**
  * Assertion methods for {@link Iterable} of {@link Node}.
@@ -36,8 +43,19 @@ public class MultipleNodeAssert extends FactoryBasedNavigableIterableAssert<Mult
         void accept(SingleNodeAssert t);
     }
 
-    MultipleNodeAssert(Iterable<Node> nodes) {
+    private MultipleNodeAssert(Iterable<Node> nodes) {
         super(nodes, MultipleNodeAssert.class, new NodeAssertFactory());
+    }
+
+    static MultipleNodeAssert create(Object xmlSource, XPathEngine xPathEngine, DocumentBuilderFactory dbf, String xPath) {
+
+        Assertions.assertThat(xPath).isNotBlank();
+
+        Source s = Input.from(xmlSource).build();
+        Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);
+        Iterable<Node> nodes = xPathEngine.selectNodes(xPath, root);
+
+        return new MultipleNodeAssert(nodes);
     }
 
     /**

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -58,7 +58,6 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
 
         Assertions.assertThat(schemaSources)
                 .isNotNull()
-                .isNotEmpty()
                 .doesNotContainNull();
 
         Source source = Input.from(xmlSource).build();
@@ -94,7 +93,7 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
         JAXPValidator validator = new JAXPValidator(Languages.W3C_XML_SCHEMA_NS_URI);
         if (schema != null) {
             validator.setSchema(schema);
-        } else {
+        } else if (schemaSources != null && schemaSources.length > 0) {
             validator.setSchemaSources(schemaSources);
         }
         return validator.validateInstance(actual);

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -1,0 +1,74 @@
+package org.xmlunit.assertj;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.xmlunit.builder.Input;
+import org.xmlunit.validation.JAXPValidator;
+import org.xmlunit.validation.Languages;
+import org.xmlunit.validation.ValidationResult;
+
+import javax.xml.transform.Source;
+import javax.xml.validation.Schema;
+
+public class ValidationAssert extends AbstractAssert<ValidationAssert, Object> {
+
+    private final Source[] schemaSource;
+    private final Schema schema;
+    private ValidationResult result;
+
+    private ValidationAssert(Object actual, Source[] schemaSource, Schema schema) {
+        super(actual, ValidationAssert.class);
+        this.schemaSource = schemaSource;
+        this.schema = schema;
+    }
+
+    static ValidationAssert create(Object xmlSource, Object... schemaSource) {
+
+        Assertions.assertThat(schemaSource)
+                .isNotNull()
+                .isNotEmpty()
+                .doesNotContainNull();
+
+        Source[] sources = new Source[schemaSource.length];
+
+        for (int i = 0; i < schemaSource.length; i++) {
+            sources[i] = Input.from(schemaSource[i]).build();
+        }
+
+        return new ValidationAssert(xmlSource, sources, null);
+    }
+
+    static ValidationAssert create(Object xmlSource, Schema schema) {
+        Assertions.assertThat(schema).isNotNull();
+
+        return new ValidationAssert(xmlSource, null, schema);
+    }
+
+    private void validate() {
+        if (result == null) {
+            Source source = Input.from(actual).build();
+            JAXPValidator validator = new JAXPValidator(Languages.W3C_XML_SCHEMA_NS_URI);
+            if (schema != null) {
+                validator.setSchema(schema);
+            } else {
+                validator.setSchemaSources(schemaSource);
+            }
+            this.result = validator.validateInstance(source);
+        }
+    }
+
+    public ValidationAssert isValid() {
+        validate();
+        if (!result.isValid()) {
+            failWithMessage("dupa");
+        }
+        return this;
+    }
+
+    public void isNotValid() {
+        validate();
+        if (result.isValid()) {
+            failWithMessage("dupa");
+        }
+    }
+}

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -10,67 +10,80 @@ import org.xmlunit.validation.ValidationResult;
 import javax.xml.transform.Source;
 import javax.xml.validation.Schema;
 
-public class ValidationAssert extends AbstractAssert<ValidationAssert, Object> {
+import static org.xmlunit.assertj.error.ShouldBeInvalid.shouldBeInvalid;
+import static org.xmlunit.assertj.error.ShouldBeValid.shouldBeValid;
+
+public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
 
     private final Source[] schemaSource;
     private final Schema schema;
 
-    private ValidationAssert(Object actual, Source[] schemaSource, Schema schema) {
+    private ValidationAssert(Source actual, Source[] schemaSource, Schema schema) {
         super(actual, ValidationAssert.class);
         this.schemaSource = schemaSource;
         this.schema = schema;
     }
 
-    static ValidationAssert create(Object xmlSource, Object... schemaSource) {
+    static ValidationAssert create(Object xmlSource, Object... schemaSources) {
 
-        Assertions.assertThat(schemaSource)
+        Assertions.assertThat(xmlSource).isNotNull();
+
+        Assertions.assertThat(schemaSources)
                 .isNotNull()
                 .isNotEmpty()
                 .doesNotContainNull();
 
-        Source[] sources = new Source[schemaSource.length];
+        Source source = Input.from(xmlSource).build();
 
-        for (int i = 0; i < schemaSource.length; i++) {
-            sources[i] = Input.from(schemaSource[i]).build();
+        Source[] sources = new Source[schemaSources.length];
+
+        for (int i = 0; i < schemaSources.length; i++) {
+            sources[i] = Input.from(schemaSources[i]).build();
         }
 
-        return new ValidationAssert(xmlSource, sources, null);
+        return new ValidationAssert(source, sources, null);
     }
 
     static ValidationAssert create(Object xmlSource, Schema schema) {
+
+        Assertions.assertThat(xmlSource).isNotNull();
         Assertions.assertThat(schema).isNotNull();
 
-        return new ValidationAssert(xmlSource, null, schema);
+        Source source = Input.from(xmlSource).build();
+
+        return new ValidationAssert(source, null, schema);
+    }
+
+    static ValidationAssert create(Object xmlSource) {
+
+        Source source = Input.from(xmlSource).build();
+
+        return new ValidationAssert(source, null, null);
     }
 
     private ValidationResult validate() {
 
-        Source source = Input.from(actual).build();
         JAXPValidator validator = new JAXPValidator(Languages.W3C_XML_SCHEMA_NS_URI);
         if (schema != null) {
             validator.setSchema(schema);
         } else {
             validator.setSchemaSources(schemaSource);
         }
-        return validator.validateInstance(source);
+        return validator.validateInstance(actual);
     }
 
     public ValidationAssert isValid() {
         ValidationResult validationResult = validate();
         if (!validationResult.isValid()) {
-            failWithMessage("error message");
+            throwAssertionError(shouldBeValid(actual.getSystemId(), validationResult.getProblems()));
         }
         return this;
     }
 
-    public void isNotValid() {
-         ValidationResult validateResult = validate();
-        if (validateResult.isValid()) {
-            failWithMessage("error message");
-        }
-    }
-
     public void isInvalid() {
-        isNotValid();
+        ValidationResult validateResult = validate();
+        if (validateResult.isValid()) {
+            throwAssertionError(shouldBeInvalid(actual.getSystemId()));
+        }
     }
 }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -15,12 +15,12 @@ import static org.xmlunit.assertj.error.ShouldBeValid.shouldBeValid;
 
 public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
 
-    private final Source[] schemaSource;
+    private final Source[] schemaSources;
     private final Schema schema;
 
-    private ValidationAssert(Source actual, Source[] schemaSource, Schema schema) {
+    private ValidationAssert(Source actual, Source[] schemaSources, Schema schema) {
         super(actual, ValidationAssert.class);
-        this.schemaSource = schemaSource;
+        this.schemaSources = schemaSources;
         this.schema = schema;
     }
 
@@ -67,7 +67,7 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
         if (schema != null) {
             validator.setSchema(schema);
         } else {
-            validator.setSchemaSources(schemaSource);
+            validator.setSchemaSources(schemaSources);
         }
         return validator.validateInstance(actual);
     }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -14,7 +14,6 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Object> {
 
     private final Source[] schemaSource;
     private final Schema schema;
-    private ValidationResult result;
 
     private ValidationAssert(Object actual, Source[] schemaSource, Schema schema) {
         super(actual, ValidationAssert.class);
@@ -44,31 +43,34 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Object> {
         return new ValidationAssert(xmlSource, null, schema);
     }
 
-    private void validate() {
-        if (result == null) {
-            Source source = Input.from(actual).build();
-            JAXPValidator validator = new JAXPValidator(Languages.W3C_XML_SCHEMA_NS_URI);
-            if (schema != null) {
-                validator.setSchema(schema);
-            } else {
-                validator.setSchemaSources(schemaSource);
-            }
-            this.result = validator.validateInstance(source);
+    private ValidationResult validate() {
+
+        Source source = Input.from(actual).build();
+        JAXPValidator validator = new JAXPValidator(Languages.W3C_XML_SCHEMA_NS_URI);
+        if (schema != null) {
+            validator.setSchema(schema);
+        } else {
+            validator.setSchemaSources(schemaSource);
         }
+        return validator.validateInstance(source);
     }
 
     public ValidationAssert isValid() {
-        validate();
-        if (!result.isValid()) {
-            failWithMessage("dupa");
+        ValidationResult validationResult = validate();
+        if (!validationResult.isValid()) {
+            failWithMessage("error message");
         }
         return this;
     }
 
     public void isNotValid() {
-        validate();
-        if (result.isValid()) {
-            failWithMessage("dupa");
+         ValidationResult validateResult = validate();
+        if (validateResult.isValid()) {
+            failWithMessage("error message");
         }
+    }
+
+    public void isInvalid() {
+        isNotValid();
     }
 }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValidationAssert.java
@@ -1,3 +1,16 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package org.xmlunit.assertj;
 
 import org.assertj.core.api.AbstractAssert;
@@ -13,6 +26,21 @@ import javax.xml.validation.Schema;
 import static org.xmlunit.assertj.error.ShouldBeInvalid.shouldBeInvalid;
 import static org.xmlunit.assertj.error.ShouldBeValid.shouldBeValid;
 
+/**
+ * Assertion methods for XML validation.
+ *
+ * <p><b>Simple Example</b></p>
+ *
+ * <pre>
+ * import static org.xmlunit.assertj.XmlAssert.assertThat;
+ *
+ * final String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *
+ * assertThat(xml).isValid();
+ * </pre>
+ *
+ * @since XMLUnit 2.6.1
+ */
 public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
 
     private final Source[] schemaSources;
@@ -72,6 +100,11 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
         return validator.validateInstance(actual);
     }
 
+    /**
+     * Verifies that actual value is valid against given schema
+     *
+     * @throws AssertionError if the actual value is not valid against schema
+     */
     public ValidationAssert isValid() {
         ValidationResult validationResult = validate();
         if (!validationResult.isValid()) {
@@ -80,6 +113,11 @@ public class ValidationAssert extends AbstractAssert<ValidationAssert, Source> {
         return this;
     }
 
+    /**
+     * Verifies that actual value is not valid against given schema
+     *
+     * @throws AssertionError if the actual value is valid against schema
+     */
     public void isInvalid() {
         ValidationResult validateResult = validate();
         if (validateResult.isValid()) {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -1,9 +1,6 @@
 package org.xmlunit.assertj;
 
-import org.assertj.core.api.AbstractCharSequenceAssert;
-import org.assertj.core.api.AbstractDoubleAssert;
-import org.assertj.core.api.AbstractIntegerAssert;
-import org.assertj.core.api.Assertions;
+import org.assertj.core.api.*;
 import org.w3c.dom.Node;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
@@ -61,6 +58,23 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         return Assertions.assertThat(value);
     }
 
+    public AbstractBooleanAssert<?> asBoolean() {
+        isNotNull();
+        boolean value = false;
+        switch (actual.toLowerCase()) {
+            case "1":
+            case "true":
+                value = true; break;
+            case "0":
+            case "false":
+                value = false; break;
+            default:
+                throwAssertionError(shouldBeConvertible(actual, "boolean"));
+        }
+
+        return Assertions.assertThat(value);
+    }
+
     public XmlAssert asXml() {
         return XmlAssert.assertThat(actual);
     }
@@ -73,6 +87,12 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
 
     public ValueAssert isEqualTo(double expected) {
         asDouble().isEqualTo(expected);
+
+        return this;
+    }
+
+    public ValueAssert isEqualTo(boolean expected) {
+        asBoolean().isEqualTo(expected);
 
         return this;
     }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -13,7 +13,11 @@
 */
 package org.xmlunit.assertj;
 
-import org.assertj.core.api.*;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.Assertions;
 import org.w3c.dom.Node;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -1,0 +1,75 @@
+package org.xmlunit.assertj;
+
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.Assertions;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.util.Convert;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Source;
+import java.util.Map;
+
+import static org.xmlunit.assertj.error.ShouldBeConvertible.shouldBeConvertible;
+
+public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String> {
+
+    private ValueAssert(String value) {
+        super(value, ValueAssert.class);
+    }
+
+    static ValueAssert create(Object xmlSource, Map<String, String> prefix2Uri, DocumentBuilderFactory dbf, String xPath) {
+        Assertions.assertThat(xPath).isNotBlank();
+
+        final JAXPXPathEngine engine = new JAXPXPathEngine();
+        if (prefix2Uri != null) {
+            engine.setNamespaceContext(prefix2Uri);
+        }
+
+        Source s = Input.from(xmlSource).build();
+        Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);
+        String value = engine.evaluate(xPath, root);
+
+        return new ValueAssert(value)
+                .describedAs("XPath \"%s\" evaluated to value", xPath);
+    }
+
+    public AbstractIntegerAssert<?> asInt() {
+        isNotNull();
+        int value = 0;
+        try {
+            value = Integer.parseInt(actual);
+        } catch (NumberFormatException e) {
+            throwAssertionError(shouldBeConvertible(actual, "int"));
+        }
+
+        return Assertions.assertThat(value);
+    }
+
+    public AbstractDoubleAssert<?> asDouble() {
+        isNotNull();
+        double value = 0;
+        try {
+            value = Double.parseDouble(actual);
+        } catch (NumberFormatException e) {
+            throwAssertionError(shouldBeConvertible(actual, "double"));
+        }
+
+        return Assertions.assertThat(value);
+    }
+
+    public ValueAssert isEqualTo(int expected) {
+        asInt().isEqualTo(expected);
+
+        return this;
+    }
+
+    public ValueAssert isEqualTo(double expected) {
+        asDouble().isEqualTo(expected);
+
+        return this;
+    }
+}

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -1,3 +1,16 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package org.xmlunit.assertj;
 
 import org.assertj.core.api.*;
@@ -12,6 +25,21 @@ import java.util.Map;
 
 import static org.xmlunit.assertj.error.ShouldBeConvertible.shouldBeConvertible;
 
+/**
+ * Assertion methods for {@link String} result of XPath evaluation.
+ *
+ * <p><b>Simple Example</b></p>
+ *
+ * <pre>
+ * import static org.xmlunit.assertj.XmlAssert.assertThat;
+ *
+ * final String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *
+ * assertThat(xml).valueByXPath("count(//a/b)").isEqualTo(3);
+ * </pre>
+ *
+ * @since XMLUnit 2.6.1
+ */
 public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String> {
 
     private ValueAssert(String value) {
@@ -34,6 +62,12 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
                 .describedAs("XPath \"%s\" evaluated to value", xPath);
     }
 
+    /**
+     * Returns an {@code Assert} object that allows performing assertions on integer value of the {@link String} under test.
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value does not contain a parsable integer
+     */
     public AbstractIntegerAssert<?> asInt() {
         isNotNull();
         int value = 0;
@@ -46,6 +80,12 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         return Assertions.assertThat(value);
     }
 
+    /**
+     * Returns an {@code Assert} object that allows performing assertions on integer value of the {@link String} under test.
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value does not contain a parsable double
+     */
     public AbstractDoubleAssert<?> asDouble() {
         isNotNull();
         double value = 0;
@@ -58,16 +98,26 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         return Assertions.assertThat(value);
     }
 
+    /**
+     * Returns an {@code Assert} object that allows performing assertions on boolean value of the {@link String} under test.
+     * <p>
+     * If actual value after lowercasing is one of the following "true", "false", "1", "0", then it can be parsed to boolean.
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value does not contain a parsable boolean
+     */
     public AbstractBooleanAssert<?> asBoolean() {
         isNotNull();
         boolean value = false;
         switch (actual.toLowerCase()) {
             case "1":
             case "true":
-                value = true; break;
+                value = true;
+                break;
             case "0":
             case "false":
-                value = false; break;
+                value = false;
+                break;
             default:
                 throwAssertionError(shouldBeConvertible(actual, "boolean"));
         }
@@ -75,22 +125,37 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         return Assertions.assertThat(value);
     }
 
+    /**
+     * Returns an {@code XmlAssert} object that allows performing assertions on XML value of the {@link String} under test.
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     */
     public XmlAssert asXml() {
+        isNotNull();
         return XmlAssert.assertThat(actual);
     }
 
+    /**
+     * Try convert the {@link String} under test to int using {@link #asInt()} and compare with given value.
+     */
     public ValueAssert isEqualTo(int expected) {
         asInt().isEqualTo(expected);
 
         return this;
     }
 
+    /**
+     * Try convert the {@link String} under test to double using {@link #asDouble()} and compare with given value.
+     */
     public ValueAssert isEqualTo(double expected) {
         asDouble().isEqualTo(expected);
 
         return this;
     }
 
+    /**
+     * Try convert the {@link String} under test to boolean using {@link #asBoolean()} and compare with given value.
+     */
     public ValueAssert isEqualTo(boolean expected) {
         asBoolean().isEqualTo(expected);
 

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -61,6 +61,10 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         return Assertions.assertThat(value);
     }
 
+    public XmlAssert asXml() {
+        return XmlAssert.assertThat(actual);
+    }
+
     public ValueAssert isEqualTo(int expected) {
         asInt().isEqualTo(expected);
 

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -149,33 +149,39 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
         return null;
     }
 
-    public ValidationAssert isValid() {
+    public XmlAssert isValid() {
         isNotNull();
-        return ValidationAssert.create(actual).isValid();
+        ValidationAssert.create(actual).isValid();
+        return this;
     }
 
-    public void isInvalid() {
+    public XmlAssert isInvalid() {
         isNotNull();
         ValidationAssert.create(actual).isInvalid();
+        return this;
     }
 
-    public ValidationAssert isValidAgainst(Schema schema) {
+    public XmlAssert isValidAgainst(Schema schema) {
         isNotNull();
-        return ValidationAssert.create(actual, schema).isValid();
+        ValidationAssert.create(actual, schema).isValid();
+        return this;
     }
 
-    public void isNotValidAgainst(Schema schema) {
+    public XmlAssert isNotValidAgainst(Schema schema) {
         isNotNull();
         ValidationAssert.create(actual, schema).isInvalid();
+        return this;
     }
 
-    public ValidationAssert isValidAgainst(Object... schemaSources) {
+    public XmlAssert isValidAgainst(Object... schemaSources) {
         isNotNull();
-        return ValidationAssert.create(actual, schemaSources).isValid();
+        ValidationAssert.create(actual, schemaSources).isValid();
+        return this;
     }
 
-    public void isNotValidAgainst(Object... schemaSources) {
+    public XmlAssert isNotValidAgainst(Object... schemaSources) {
         isNotNull();
         ValidationAssert.create(actual, schemaSources).isInvalid();
+        return this;
     }
 }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -14,10 +14,7 @@
 package org.xmlunit.assertj;
 
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.Assertions;
 import org.xmlunit.builder.Input;
-import org.xmlunit.xpath.JAXPXPathEngine;
-import org.xmlunit.xpath.XPathEngine;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.validation.Schema;
@@ -140,6 +137,16 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
      */
     public void doesNotHaveXPath(String xPath) {
         nodesByXPath(xPath).doNotExist();
+    }
+
+    public ValueAssert valueByXPath(String xPath) {
+        isNotNull();
+        try {
+            return ValueAssert.create(actual, prefix2Uri, dbf, xPath);
+        } catch (Exception e) {
+            throwAssertionError(shouldNotHaveThrown(e));
+        }
+        return null;
     }
 
     public ValidationAssert isValid() {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -84,42 +84,6 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
     }
 
     /**
-     * Create {@link MultipleNodeAssert} from nodes selecting by given <b>xPath</b>.
-     *
-     * @throws AssertionError if the actual value is {@code null}.
-     * @throws AssertionError if the actual value provide invalid XML.
-     */
-    public MultipleNodeAssert nodesByXPath(String xPath) {
-        isNotNull();
-        Assertions.assertThat(xPath).isNotBlank();
-
-        try {
-            XPathEngine xPathEngine = createXPathEngine();
-            return MultipleNodeAssert.create(actual, xPathEngine, dbf, xPath);
-
-        } catch (Exception e) {
-
-            throwAssertionError(shouldNotHaveThrown(e));
-        }
-
-        return null;
-    }
-
-    /**
-     * Equivalent for <pre>{@link #nodesByXPath(String) nodesByXPath(xPath)}.{@link MultipleNodeAssert#exist() exist()}</pre>
-     */
-    public MultipleNodeAssert hasXPath(String xPath) {
-        return nodesByXPath(xPath).exist();
-    }
-
-    /**
-     * Equivalent for <pre>{@link #nodesByXPath(String) nodesByXPath(xPath)}.{@link MultipleNodeAssert#doNotExist() doNotExist()}</pre>
-     */
-    public void doesNotHaveXPath(String xPath) {
-        nodesByXPath(xPath).doNotExist();
-    }
-
-    /**
      * Sets the {@link DocumentBuilderFactory} to use when creating a
      * {@link org.w3c.dom.Document} from the XML input.
      *
@@ -142,6 +106,40 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
         isNotNull();
         this.prefix2Uri = prefix2Uri;
         return this;
+    }
+
+    /**
+     * Create {@link MultipleNodeAssert} from nodes selecting by given <b>xPath</b>.
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value provide invalid XML.
+     */
+    public MultipleNodeAssert nodesByXPath(String xPath) {
+        isNotNull();
+
+        try {
+            return MultipleNodeAssert.create(actual, prefix2Uri, dbf, xPath);
+
+        } catch (Exception e) {
+
+            throwAssertionError(shouldNotHaveThrown(e));
+        }
+
+        return null;
+    }
+
+    /**
+     * Equivalent for <pre>{@link #nodesByXPath(String) nodesByXPath(xPath)}.{@link MultipleNodeAssert#exist() exist()}</pre>
+     */
+    public MultipleNodeAssert hasXPath(String xPath) {
+        return nodesByXPath(xPath).exist();
+    }
+
+    /**
+     * Equivalent for <pre>{@link #nodesByXPath(String) nodesByXPath(xPath)}.{@link MultipleNodeAssert#doNotExist() doNotExist()}</pre>
+     */
+    public void doesNotHaveXPath(String xPath) {
+        nodesByXPath(xPath).doNotExist();
     }
 
     public ValidationAssert isValid() {
@@ -172,15 +170,5 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
     public void isNotValidAgainst(Object... schemaSources) {
         isNotNull();
         ValidationAssert.create(actual, schemaSources).isInvalid();
-    }
-
-    private XPathEngine createXPathEngine() {
-
-        final JAXPXPathEngine engine = new JAXPXPathEngine();
-        if (prefix2Uri != null) {
-            engine.setNamespaceContext(prefix2Uri);
-        }
-
-        return engine;
     }
 }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -32,13 +32,13 @@ import static org.xmlunit.assertj.error.ShouldNotHaveThrown.shouldNotHaveThrown;
  * <p><b>Simple Example</b></p>
  *
  * <pre>
- * import static org.xmlunit.assertj.XmlAssert.assertThat;
+ *    import static org.xmlunit.assertj.XmlAssert.assertThat;
  *
- * final String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *    final String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
  *
- * assertThat(xml).nodesByXPath("//a/b/@attr").exist();
- * assertThat(xml).hasXPath("//a/b/@attr");
- * assertThat(xml).doesNotHaveXPath("//a/b/c");
+ *    assertThat(xml).nodesByXPath("//a/b/@attr").exist();
+ *    assertThat(xml).hasXPath("//a/b/@attr");
+ *    assertThat(xml).doesNotHaveXPath("//a/b/c");
  * </pre>
  *
  * <p><b>Example with namespace mapping</b></p>
@@ -60,6 +60,24 @@ import static org.xmlunit.assertj.error.ShouldNotHaveThrown.shouldNotHaveThrown;
  *          .hasXPath(&quot;//atom:feed/atom:entry/atom:id&quot;));
  * </pre>
  *
+ * <p><b>Testing XPath expression value</b></p>
+ *
+ * <pre>
+ *    String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *
+ *    assertThat(xml).valueByXPath("//a/b/@attr").isEqualTo("abc");
+ *    assertThat(xml).valueByXPath("count(//a/b)").isEqualTo(1);
+ * </pre>
+ *
+ * <p><b>Example with XML validation</b></p>
+ *
+ * <pre>
+ *    String xml = &quot;&lt;a&gt;&lt;b attr=\&quot;abc\&quot;&gt;&lt;/b&gt;&lt;/a&gt;&quot;;
+ *    StreamSource xsd = new StreamSource(new File("schema.xsd"));
+ *
+ *    assertThat(xml).isValid();
+ *    assertThat(xml).isValidAgainst(xsd);
+ * </pre>
  * @since XMLUnit 2.6.1
  */
 public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
@@ -108,6 +126,7 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
     /**
      * Create {@link MultipleNodeAssert} from nodes selecting by given <b>xPath</b>.
      *
+     * @throws AssertionError if the xPath is blank.
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if the actual value provide invalid XML.
      */
@@ -139,6 +158,13 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
         nodesByXPath(xPath).doNotExist();
     }
 
+    /**
+     * Create {@link ValueAssert} from value of given <b>xPath</b> expression.
+     *
+     * @throws AssertionError if the xPath is blank.
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value provide invalid XML.
+     */
     public ValueAssert valueByXPath(String xPath) {
         isNotNull();
         try {
@@ -149,36 +175,72 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
         return null;
     }
 
+    /**
+     * Check if actual value is valid against W3C XML Schema
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is invalid
+     */
     public XmlAssert isValid() {
         isNotNull();
         ValidationAssert.create(actual).isValid();
         return this;
     }
 
+    /**
+     * Check if actual value is not valid against W3C XML Schema
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is valid
+     */
     public XmlAssert isInvalid() {
         isNotNull();
         ValidationAssert.create(actual).isInvalid();
         return this;
     }
 
+    /**
+     * Check if actual value is valid against given schema
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is invalid
+     */
     public XmlAssert isValidAgainst(Schema schema) {
         isNotNull();
         ValidationAssert.create(actual, schema).isValid();
         return this;
     }
 
+    /**
+     * Check if actual value is not valid against given schema
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is valid
+     */
     public XmlAssert isNotValidAgainst(Schema schema) {
         isNotNull();
         ValidationAssert.create(actual, schema).isInvalid();
         return this;
     }
 
+    /**
+     * Check if actual value is valid against schema provided by given sources
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is invalid
+     */
     public XmlAssert isValidAgainst(Object... schemaSources) {
         isNotNull();
         ValidationAssert.create(actual, schemaSources).isValid();
         return this;
     }
 
+    /**
+     * Check if actual value is not valid against schema provided by given sources
+     *
+     * @throws AssertionError if the actual value is {@code null}.
+     * @throws AssertionError if the actual value is valid
+     */
     public XmlAssert isNotValidAgainst(Object... schemaSources) {
         isNotNull();
         ValidationAssert.create(actual, schemaSources).isInvalid();

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -15,14 +15,11 @@ package org.xmlunit.assertj;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
-import org.w3c.dom.Node;
 import org.xmlunit.builder.Input;
-import org.xmlunit.util.Convert;
 import org.xmlunit.xpath.JAXPXPathEngine;
 import org.xmlunit.xpath.XPathEngine;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.Source;
 import java.util.Map;
 
 import static org.xmlunit.assertj.error.ShouldNotHaveThrown.shouldNotHaveThrown;
@@ -78,6 +75,7 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
 
     /**
      * Factory method for {@link XmlAssert}
+     *
      * @param o object with type supported by {@link Input#from(Object)}
      */
     public static XmlAssert assertThat(Object o) {
@@ -93,16 +91,9 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
     public MultipleNodeAssert nodesByXPath(String xPath) {
         isNotNull();
 
-        Assertions.assertThat(xPath).isNotBlank();
-
         try {
             XPathEngine xPathEngine = createXPathEngine();
-
-            Source s = Input.from(actual).build();
-            Node root = dbf != null ? Convert.toNode(s, dbf) : Convert.toNode(s);
-            Iterable<Node> nodes = xPathEngine.selectNodes(xPath, root);
-
-            return new MultipleNodeAssert(nodes);
+            return MultipleNodeAssert.create(actual, xPathEngine, dbf, xPath);
 
         } catch (Exception e) {
 
@@ -143,7 +134,6 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
      *
      * @param prefix2Uri prefix2Uri maps from prefix to namespace URI. It is used to resolve
      *                   XML namespace prefixes in the XPath expression
-     *
      * @throws AssertionError if the actual value is {@code null}.
      */
     public XmlAssert withNamespaceContext(Map<String, String> prefix2Uri) {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/XmlAssert.java
@@ -20,6 +20,7 @@ import org.xmlunit.xpath.JAXPXPathEngine;
 import org.xmlunit.xpath.XPathEngine;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.Schema;
 import java.util.Map;
 
 import static org.xmlunit.assertj.error.ShouldNotHaveThrown.shouldNotHaveThrown;
@@ -90,6 +91,7 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
      */
     public MultipleNodeAssert nodesByXPath(String xPath) {
         isNotNull();
+        Assertions.assertThat(xPath).isNotBlank();
 
         try {
             XPathEngine xPathEngine = createXPathEngine();
@@ -140,6 +142,36 @@ public class XmlAssert extends AbstractAssert<XmlAssert, Object> {
         isNotNull();
         this.prefix2Uri = prefix2Uri;
         return this;
+    }
+
+    public ValidationAssert isValid() {
+        isNotNull();
+        return ValidationAssert.create(actual).isValid();
+    }
+
+    public void isInvalid() {
+        isNotNull();
+        ValidationAssert.create(actual).isInvalid();
+    }
+
+    public ValidationAssert isValidAgainst(Schema schema) {
+        isNotNull();
+        return ValidationAssert.create(actual, schema).isValid();
+    }
+
+    public void isNotValidAgainst(Schema schema) {
+        isNotNull();
+        ValidationAssert.create(actual, schema).isInvalid();
+    }
+
+    public ValidationAssert isValidAgainst(Object... schemaSources) {
+        isNotNull();
+        return ValidationAssert.create(actual, schemaSources).isValid();
+    }
+
+    public void isNotValidAgainst(Object... schemaSources) {
+        isNotNull();
+        ValidationAssert.create(actual, schemaSources).isInvalid();
     }
 
     private XPathEngine createXPathEngine() {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeConvertible.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeConvertible.java
@@ -1,7 +1,23 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package org.xmlunit.assertj.error;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 
+/**
+ * @since XMLUnit 2.6.1
+ */
 public class ShouldBeConvertible extends BasicErrorMessageFactory {
 
     public static ShouldBeConvertible shouldBeConvertible(String value, String targetType) {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeConvertible.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeConvertible.java
@@ -1,0 +1,17 @@
+package org.xmlunit.assertj.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+
+public class ShouldBeConvertible extends BasicErrorMessageFactory {
+
+    public static ShouldBeConvertible shouldBeConvertible(String value, String targetType) {
+
+        return new ShouldBeConvertible(value,targetType);
+    }
+
+    private ShouldBeConvertible(String value, String targetType) {
+        super("%nExpecting:%n <%s>%nto be convertible to%n <%s>",
+                unquotedString(value),
+                unquotedString(targetType));
+    }
+}

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeInvalid.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeInvalid.java
@@ -1,7 +1,23 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package org.xmlunit.assertj.error;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 
+/**
+ * @since XMLUnit 2.6.1
+ */
 public class ShouldBeInvalid extends BasicErrorMessageFactory {
 
     public static ShouldBeInvalid shouldBeInvalid(String systemId) {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeInvalid.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeInvalid.java
@@ -1,0 +1,15 @@
+package org.xmlunit.assertj.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+
+public class ShouldBeInvalid extends BasicErrorMessageFactory {
+
+    public static ShouldBeInvalid shouldBeInvalid(String systemId) {
+
+        return new ShouldBeInvalid(systemId != null ? systemId : "instance");
+    }
+
+    private ShouldBeInvalid(String systemId) {
+        super("%nExpecting:%n <%s>%nto be invalid", unquotedString(systemId));
+    }
+}

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
@@ -1,3 +1,16 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package org.xmlunit.assertj.error;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
@@ -5,6 +18,9 @@ import org.xmlunit.validation.ValidationProblem;
 
 import static java.lang.String.format;
 
+/**
+ * @since XMLUnit 2.6.1
+ */
 public class ShouldBeValid extends BasicErrorMessageFactory {
 
     public static ShouldBeValid shouldBeValid(String systemId, Iterable<ValidationProblem> problems) {

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
@@ -1,0 +1,36 @@
+package org.xmlunit.assertj.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.xmlunit.validation.ValidationProblem;
+
+public class ShouldBeValid extends BasicErrorMessageFactory {
+
+    public static ShouldBeValid shouldBeValid(String systemId, Iterable<ValidationProblem> problems) {
+        StringBuilder builder = new StringBuilder();
+        int index = 1;
+
+        for (ValidationProblem problem : problems) {
+            builder.append(index++).append(".");
+
+            if (problem.getLine() != ValidationProblem.UNKNOWN) {
+                builder.append(" line=").append(problem.getLine());
+            }
+            if (problem.getColumn() != ValidationProblem.UNKNOWN) {
+                builder.append(" column=").append(problem.getColumn());
+            }
+
+            builder.append(" type=").append(problem.getType());
+            builder.append(" message=").append(problem.getMessage());
+            builder.append("%n");
+        }
+
+        return new ShouldBeValid(systemId != null ? systemId : "instance", builder.toString());
+    }
+
+
+    private ShouldBeValid(String systemId, String problems) {
+        super("%nExpecting:%n <%s>%nto be valid but found following problems:%n%s",
+                unquotedString(systemId),
+                unquotedString(problems));
+    }
+}

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldBeValid.java
@@ -3,9 +3,13 @@ package org.xmlunit.assertj.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.xmlunit.validation.ValidationProblem;
 
+import static java.lang.String.format;
+
 public class ShouldBeValid extends BasicErrorMessageFactory {
 
     public static ShouldBeValid shouldBeValid(String systemId, Iterable<ValidationProblem> problems) {
+        String systemId1 = systemId != null ? systemId : "instance";
+
         StringBuilder builder = new StringBuilder();
         int index = 1;
 
@@ -13,18 +17,20 @@ public class ShouldBeValid extends BasicErrorMessageFactory {
             builder.append(index++).append(".");
 
             if (problem.getLine() != ValidationProblem.UNKNOWN) {
-                builder.append(" line=").append(problem.getLine());
+                builder.append(" line=").append(problem.getLine()).append(';');
             }
             if (problem.getColumn() != ValidationProblem.UNKNOWN) {
-                builder.append(" column=").append(problem.getColumn());
+                builder.append(" column=").append(problem.getColumn()).append(';');
             }
 
-            builder.append(" type=").append(problem.getType());
+            builder.append(" type=").append(problem.getType()).append(';');
             builder.append(" message=").append(problem.getMessage());
             builder.append("%n");
         }
 
-        return new ShouldBeValid(systemId != null ? systemId : "instance", builder.toString());
+        String problemsStr = format(builder.toString());
+
+        return new ShouldBeValid(systemId1, problemsStr);
     }
 
 

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldHaveAttribute.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ShouldHaveAttribute.java
@@ -22,18 +22,23 @@ import org.assertj.core.error.ErrorMessageFactory;
 public class ShouldHaveAttribute extends BasicErrorMessageFactory {
 
     public static ErrorMessageFactory shouldHaveAttribute(String nodeName, String attributeName) {
-        return new ShouldHaveAttribute(nodeName, attributeName, null);
+        return new ShouldHaveAttribute(nodeName, attributeName);
     }
 
     public static ErrorMessageFactory shouldHaveAttributeWithValue(String nodeName, String attributeName, String attributeValue) {
         return new ShouldHaveAttribute(nodeName, attributeName, attributeValue);
     }
 
+    private ShouldHaveAttribute(String nodeName, String attributeName) {
+        super("%nExpecting:%n <%s>%nto have attribute:%n <%s>",
+                unquotedString(nodeName),
+                unquotedString(attributeName));
+    }
+
     private ShouldHaveAttribute(String nodeName, String attributeName, String attributeValue) {
-        super("%nExpecting:%n <%s>%nto have attribute:%n <%s>" +
-                        (attributeValue != null ? "%nwith value:%n <%s>" : ""),
+        super("%nExpecting:%n <%s>%nto have attribute:%n <%s>%nwith value:%n <%s>",
                 unquotedString(nodeName),
                 unquotedString(attributeName),
-                (attributeValue != null ? unquotedString(attributeValue) : null));
+                unquotedString(attributeValue));
     }
 }

--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/package-info.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/package-info.java
@@ -15,5 +15,6 @@
 /**
  * Contains internal classes of XMLUnit's AssertJ support that are
  * only public as an implementation detail.
+ * @since XMLUnit 2.6.1
  */
 package org.xmlunit.assertj.error;

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ExpectedException.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ExpectedException.java
@@ -20,6 +20,7 @@ import org.junit.runners.model.Statement;
 
 import java.util.regex.Pattern;
 
+import static java.util.regex.Pattern.DOTALL;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 
@@ -57,7 +58,7 @@ public class ExpectedException implements TestRule {
 
         @Override
         protected boolean matchesSafely(String item) {
-            return Pattern.compile(regex).matcher(item).matches();
+            return Pattern.compile(regex, DOTALL).matcher(item).matches();
         }
 
         @Override

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ExpectedException.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ExpectedException.java
@@ -20,6 +20,7 @@ import org.junit.runners.model.Statement;
 
 import java.util.regex.Pattern;
 
+import static java.lang.String.*;
 import static java.util.regex.Pattern.DOTALL;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
@@ -41,7 +42,7 @@ public class ExpectedException implements TestRule {
 
     public void expectAssertionError(String message) {
         delegate.expect(AssertionError.class);
-        delegate.expectMessage(message);
+        delegate.expectMessage(format(message));
     }
 
     public void expectAssertionErrorPattern(String messageRegex) {

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/SingleNodeAssertHasAttributeTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/SingleNodeAssertHasAttributeTest.java
@@ -129,6 +129,7 @@ public class SingleNodeAssertHasAttributeTest {
                 .element(2)
                 .hasAttribute("attr3", "value3");
     }
+
     @Test
     public void testHasAttribute_withAnyValue_shouldFailed() {
 

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -19,7 +19,7 @@ public class ValueAssertTest {
     public ExpectedException thrown = none();
 
     @Test
-    public void testAsInt_withCountExpression_shouldPass() {
+    public void testAsInt_shouldPass() {
 
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
@@ -45,6 +45,86 @@ public class ValueAssertTest {
                 "</fruits>";
 
         assertThat(xml).valueByXPath("//fruits/fruit/@name").asInt();
+    }
+
+    @Test
+    public void testAsDouble_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" weight=\"66.6\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit/@weight").asDouble().isEqualTo(66.6);
+    }
+
+    @Test
+    public void testAsDouble_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <apple>%nto be convertible to%n <double>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" weight=\"66.6\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit/@name").asDouble();
+    }
+
+    @Test
+    public void testAsBoolean_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"orange\" fresh=\"false\"/>" +
+                "<fruit name=\"banana\" fresh=\"1\"/>" +
+                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean().isTrue();
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"orange\"]/@fresh").asBoolean().isFalse();
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"banana\"]/@fresh").asBoolean().isTrue();
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"pear\"]/@fresh").asBoolean().isFalse();
+    }
+
+    @Test
+    public void testAsBoolean_withNumberAsArgument_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <2>%nto be convertible to%n <boolean>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"2\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean();
+    }
+
+    @Test
+    public void testAsBoolean_withRandomStringAsArgument_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <asdfasd>%nto be convertible to%n <boolean>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"asdfasd\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean();
+    }
+
+    @Test
+    public void testAsXml_shouldPass() {
+
+        String xml ="<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<a><b>" +
+                "<![CDATA[<c><d attr=\"xyz\"></d></c>]]>" +
+                "</b></a>";
+
+        assertThat(xml).valueByXPath("//a/b/text()")
+                .isEqualTo("<c><d attr=\"xyz\"></d></c>")
+                .asXml().hasXPath("/c/d");
     }
 
     @Test
@@ -76,16 +156,20 @@ public class ValueAssertTest {
     }
 
     @Test
-    public void testAsXml_shouldPass() {
+    public void testIsEqualTo_withBoolean_shouldPass() {
 
-        String xml ="<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<a><b>" +
-                "<![CDATA[<c><d attr=\"xyz\"></d></c>]]>" +
-                "</b></a>";
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"orange\" fresh=\"false\"/>" +
+                "<fruit name=\"banana\" fresh=\"1\"/>" +
+                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "</fruits>";
 
-        assertThat(xml).valueByXPath("//a/b/text()")
-                .isEqualTo("<c><d attr=\"xyz\"></d></c>")
-                .asXml().hasXPath("/c/d");
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").isEqualTo(true);
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"orange\"]/@fresh").isEqualTo(false);
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"banana\"]/@fresh").isEqualTo(true);
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"pear\"]/@fresh").isEqualTo(false);
     }
 
     @Test

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -1,16 +1,13 @@
 package org.xmlunit.assertj;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
-import org.xmlunit.XMLUnitException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -20,20 +17,6 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 public class ValueAssertTest {
     @Rule
     public ExpectedException thrown = none();
-
-    @Test
-    public void testIsEqualTo_withCountExpression_shouldPass() {
-
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits>" +
-                "<fruit name=\"apple\"/>" +
-                "<fruit name=\"orange\"/>" +
-                "<fruit name=\"banana\"/>" +
-                "</fruits>";
-        assertThat(xml).valueByXPath("count(//fruits/fruit)").isEqualTo(3);
-        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"orange\"])").isEqualTo(1);
-        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"apricot\"])").isEqualTo(0);
-    }
 
     @Test
     public void testAsInt_withCountExpression_shouldPass() {
@@ -64,6 +47,33 @@ public class ValueAssertTest {
         assertThat(xml).valueByXPath("//fruits/fruit/@name").asInt();
     }
 
+    @Test
+    public void testIsEqualTo_withInt_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "<fruit name=\"orange\"/>" +
+                "<fruit name=\"banana\"/>" +
+                "</fruits>";
+        assertThat(xml).valueByXPath("count(//fruits/fruit)").isEqualTo(3);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"orange\"])").isEqualTo(1);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"apricot\"])").isEqualTo(0);
+    }
+
+    @Test
+    public void testIsEqualTo_withDouble_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" weight=\"23.3\"/>" +
+                "<fruit name=\"orange\" weight=\"0.0\"/>" +
+                "<fruit name=\"banana\" weight=\"7\"/>" +
+                "</fruits>";
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@weight").isEqualTo(23.3);
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"orange\"]/@weight").isEqualTo(0.0);
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"banana\"]/@weight").isEqualTo(7.0);
+    }
 
     @Test
     public void testIsEqualTo_withAttributeValueExpression_shouldPass() {

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -1,0 +1,133 @@
+package org.xmlunit.assertj;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xmlunit.XMLUnitException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import static org.xmlunit.assertj.ExpectedException.none;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
+
+public class ValueAssertTest {
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void testIsEqualTo_withCountExpression_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "<fruit name=\"orange\"/>" +
+                "<fruit name=\"banana\"/>" +
+                "</fruits>";
+        assertThat(xml).valueByXPath("count(//fruits/fruit)").isEqualTo(3);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"orange\"])").isEqualTo(1);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"apricot\"])").isEqualTo(0);
+    }
+
+    @Test
+    public void testAsInt_withCountExpression_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "<fruit name=\"orange\"/>" +
+                "<fruit name=\"banana\"/>" +
+                "</fruits>";
+        assertThat(xml).valueByXPath("count(//fruits/fruit)").asInt().isEqualTo(3);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"orange\"])").asInt().isEqualTo(1);
+        assertThat(xml).valueByXPath("count(//fruits/fruit[@name=\"apricot\"])").asInt().isEqualTo(0);
+    }
+
+    @Test
+    public void testAsInt_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <apple>%nto be convertible to%n <int>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "<fruit name=\"orange\"/>" +
+                "<fruit name=\"banana\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit/@name").asInt();
+    }
+
+
+    @Test
+    public void testIsEqualTo_withAttributeValueExpression_shouldPass() {
+
+        String xml = "<a><b attr=\"abc\"></b></a>";
+
+        assertThat(xml).valueByXPath("//a/b/@attr").isEqualTo("abc");
+    }
+
+    @Test
+    public void testIsEqualTo_withAttributeValueExpression_shouldFailed() {
+
+        thrown.expectAssertionError("expected:<\"[something]\"> but was:<\"[abc]\">");
+
+        String xml = "<a><b attr=\"abc\"></b></a>";
+
+        assertThat(xml).valueByXPath("//a/b/@attr").isEqualTo("something");
+    }
+
+    @Test
+    public void testIsEqualTo_withAttributeValueExpression_fromElementClass_shouldPass() throws Exception {
+
+        String xml = "<a><b attr=\"abc\"></b></a>";
+
+        DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
+        f.setNamespaceAware(true);
+        DocumentBuilder db = f.newDocumentBuilder();
+        Element xmlRootElement = db.parse(new InputSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)))).getDocumentElement();
+
+        assertThat(xmlRootElement).valueByXPath("//a/b/@attr").isEqualTo("abc");
+    }
+
+    @Test
+    public void testIsEqualTo_withNamespaceContext_shouldPass() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<feed xmlns=\"http://www.w3.org/2005/Atom\">" +
+                "   <title>Search Engine Feed</title>" +
+                "   <link href=\"https://en.wikipedia.org/wiki/Web_search_engine\"/>" +
+                "   <entry>" +
+                "       <title>Google</title>" +
+                "       <id>goog</id>" +
+                "   </entry>" +
+                "   <entry>" +
+                "       <title>Bing</title>" +
+                "       <id>msft</id>" +
+                "   </entry>" +
+                "</feed>";
+
+        HashMap<String, String> prefix2Uri = new HashMap<>();
+        prefix2Uri.put("atom", "http://www.w3.org/2005/Atom");
+
+        assertThat(xml).withNamespaceContext(prefix2Uri)
+                .valueByXPath("count(//atom:feed/atom:entry)").isEqualTo("2");
+        assertThat(xml).withNamespaceContext(prefix2Uri)
+                .valueByXPath("//atom:feed/atom:entry/atom:title/text()").isEqualTo("Google");
+        assertThat(xml).withNamespaceContext(prefix2Uri)
+                .valueByXPath("//atom:feed/atom:entry[2]/atom:title/text()").isEqualTo("Bing");
+    }
+
+    @Test
+    public void testValueByXpath_withInvalidXml_shouldFailed() {
+        thrown.expectAssertionErrorPattern(".*Expecting code not to raise a throwable but caught.*Content is not allowed in prolog.*");
+
+        assertThat("not empty").valueByXPath("count(//atom:feed/atom:entry)").isEmpty();
+    }
+}

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -76,6 +76,19 @@ public class ValueAssertTest {
     }
 
     @Test
+    public void testAsXml_shouldPass() {
+
+        String xml ="<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<a><b>" +
+                "<![CDATA[<c><d attr=\"xyz\"></d></c>]]>" +
+                "</b></a>";
+
+        assertThat(xml).valueByXPath("//a/b/text()")
+                .isEqualTo("<c><d attr=\"xyz\"></d></c>")
+                .asXml().hasXPath("/c/d");
+    }
+
+    @Test
     public void testIsEqualTo_withAttributeValueExpression_shouldPass() {
 
         String xml = "<a><b attr=\"abc\"></b></a>";

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
@@ -1,0 +1,129 @@
+package org.xmlunit.assertj;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.xmlunit.validation.Languages;
+
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.File;
+
+import static org.xmlunit.assertj.ExpectedException.none;
+import static org.xmlunit.assertj.XmlAssert.assertThat;
+
+public class XmlAssertValidationTest {
+
+    @Rule
+    public ExpectedException thrown = none();
+
+    @Test
+    public void testIsValidateAgainst_shouldPass() {
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+        StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
+
+        assertThat(xml).isValidAgainst(xsd);
+    }
+
+    @Test
+    public void testIsValidateAgainst_withExternallyCreatedSchemaInstance_shouldPass() throws Exception {
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+        StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
+
+        SchemaFactory factory = SchemaFactory.newInstance(Languages.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = factory.newSchema(xsd);
+
+        assertThat(xml).isValidAgainst(schema);
+    }
+
+    @Test
+    public void testIsNotValidateAgainst_withBrokenXml_shouldPass() {
+        final StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+        final StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
+
+        assertThat(xml).isNotValidAgainst(xsd);
+    }
+
+    @Test
+    public void testIsNotValidateAgainst_withBrokenXml_andExternallyCreatedSchemaInstance_shouldPass() throws Exception {
+        StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+        StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
+
+        SchemaFactory factory = SchemaFactory.newInstance(Languages.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = factory.newSchema(xsd);
+
+        assertThat(xml).isNotValidAgainst(schema);
+    }
+
+    @Test
+    public void testIsValidateAgainst_withBrokenXml_shouldFailed() {
+
+        thrown.expectAssertionErrorPattern("^\\nExpecting:\\n <.*\\.\\.\\/test-resources\\/invalidBook.xml>\\nto be valid but found following problems:\\n.*");
+        thrown.expectAssertionError("1. line=9 column=8 type=ERROR " +
+                "message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete. " +
+                "One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+        StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
+
+        assertThat(xml).isValidAgainst(xsd);
+    }
+
+    @Test
+    public void testIsValid_shouldPass() {
+
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+
+        assertThat(xml).isValid();
+    }
+
+    @Test
+    public void testIsValid_withBrokenXml_shouldPass() {
+
+        thrown.expectAssertionError("1. line=9 column=8 type=ERROR " +
+                "message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete. " +
+                "One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+
+        assertThat(xml).isValid();
+    }
+
+    @Test
+    public void testIsInValid_withBrokenXml_shouldPass() {
+
+        StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+
+        assertThat(xml).isInvalid();
+    }
+
+    @Test
+    public void testIsInvalid_shouldPass() {
+
+        thrown.expectAssertionErrorPattern("^\\nExpecting:\\n <.*\\.\\.\\/test-resources\\/BookXsdGenerated.xml>\\nto be invalid");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+
+        assertThat(xml).isInvalid();
+    }
+
+    @Test
+    public void testIsValidAgainst_withNullSchemaSources_shouldFailed() {
+
+        thrown.expectAssertionError("actual not to be null");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+
+        assertThat(xml).isValidAgainst((Object[]) null);
+    }
+
+    @Test
+    public void testIsValidAgainst_withNullSchema_shouldFailed() {
+
+        thrown.expectAssertionError("actual not to be null");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+
+        assertThat(xml).isValidAgainst((Schema) null);
+    }
+}

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
@@ -18,7 +18,7 @@ public class XmlAssertValidationTest {
     public ExpectedException thrown = none();
 
     @Test
-    public void testIsValidateAgainst_shouldPass() {
+    public void testIsValidAgainst_shouldPass() {
         StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
         StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
 
@@ -26,7 +26,7 @@ public class XmlAssertValidationTest {
     }
 
     @Test
-    public void testIsValidateAgainst_withExternallyCreatedSchemaInstance_shouldPass() throws Exception {
+    public void testIsValidAgainst_withExternallyCreatedSchemaInstance_shouldPass() throws Exception {
         StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
         StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
 
@@ -37,7 +37,7 @@ public class XmlAssertValidationTest {
     }
 
     @Test
-    public void testIsNotValidateAgainst_withBrokenXml_shouldPass() {
+    public void testIsNotValidAgainst_withBrokenXml_shouldPass() {
         final StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
         final StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
 
@@ -45,7 +45,7 @@ public class XmlAssertValidationTest {
     }
 
     @Test
-    public void testIsNotValidateAgainst_withBrokenXml_andExternallyCreatedSchemaInstance_shouldPass() throws Exception {
+    public void testIsNotValidAgainst_withBrokenXml_andExternallyCreatedSchemaInstance_shouldPass() throws Exception {
         StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
         StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
 
@@ -56,12 +56,12 @@ public class XmlAssertValidationTest {
     }
 
     @Test
-    public void testIsValidateAgainst_withBrokenXml_shouldFailed() {
+    public void testIsValidAgainst_withBrokenXml_shouldFailed() {
 
         thrown.expectAssertionErrorPattern("^\\nExpecting:\\n <.*\\.\\.\\/test-resources\\/invalidBook.xml>\\nto be valid but found following problems:\\n.*");
-        thrown.expectAssertionError("1. line=9 column=8 type=ERROR " +
-                "message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete. " +
-                "One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
+        thrown.expectAssertionError("1. line=9; column=8; type=ERROR;" +
+                " message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete." +
+                " One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
 
         StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
         StreamSource xsd = new StreamSource(new File("../test-resources/Book.xsd"));
@@ -80,9 +80,9 @@ public class XmlAssertValidationTest {
     @Test
     public void testIsValid_withBrokenXml_shouldPass() {
 
-        thrown.expectAssertionError("1. line=9 column=8 type=ERROR " +
-                "message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete. " +
-                "One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
+        thrown.expectAssertionError("1. line=9; column=8; type=ERROR;" +
+                " message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete." +
+                " One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
 
         StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
 
@@ -90,7 +90,7 @@ public class XmlAssertValidationTest {
     }
 
     @Test
-    public void testIsInValid_withBrokenXml_shouldPass() {
+    public void testIsInvalid_withBrokenXml_shouldPass() {
 
         StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
 

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
@@ -70,6 +70,27 @@ public class XmlAssertValidationTest {
     }
 
     @Test
+    public void testIsValidAgainst_withEmptySourcesArray_shouldPass() {
+
+        StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
+
+        assertThat(xml).isValidAgainst();
+        assertThat(xml).isValidAgainst(new Object[0]);
+    }
+
+    @Test
+    public void testIsValidAgainst_withBrokenXmlAndEmptySourcesArray_shouldFailed() {
+
+        thrown.expectAssertionError("1. line=9; column=8; type=ERROR;" +
+                " message=cvc-complex-type.2.4.b: The content of element 'Book' is not complete." +
+                " One of '{\"https://www.xmlunit.org/publishing\":Publisher}' is expected.");
+
+        StreamSource xml = new StreamSource(new File("../test-resources/invalidBook.xml"));
+
+        assertThat(xml).isValidAgainst();
+    }
+
+    @Test
     public void testIsValid_shouldPass() {
 
         StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));


### PR DESCRIPTION
Following features were add to assertj module:
- check validation API, equivalent of `ValidationMatcher`
- check value of XPath expresion API, equivalent of `EvaluateXPathMatcher`