### PR TITLE
Add TypeMatcher in xmlunit-matchers

### DIFF
--- a/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
+++ b/xmlunit-assertj/src/main/java/org/xmlunit/assertj/ValueAssert.java
@@ -106,7 +106,7 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
     /**
      * Returns an {@code Assert} object that allows performing assertions on boolean value of the {@link String} under test.
      * <p>
-     * If actual value after lowercasing is one of the following "true", "false", "1", "0", then it can be parsed to boolean.
+     * If actual value after lowercasing is one of the following "true", "false", then it can be parsed to boolean.
      *
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if the actual value does not contain a parsable boolean
@@ -115,11 +115,9 @@ public class ValueAssert extends AbstractCharSequenceAssert<ValueAssert, String>
         isNotNull();
         boolean value = false;
         switch (actual.toLowerCase()) {
-            case "1":
             case "true":
                 value = true;
                 break;
-            case "0":
             case "false":
                 value = false;
                 break;

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -91,10 +91,10 @@ public class ValueAssertTest {
 
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
-                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"apple\" fresh=\"true\"/>" +
                 "<fruit name=\"orange\" fresh=\"false\"/>" +
-                "<fruit name=\"banana\" fresh=\"1\"/>" +
-                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "<fruit name=\"banana\" fresh=\"True\"/>" +
+                "<fruit name=\"pear\" fresh=\"False\"/>" +
                 "</fruits>";
 
         assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean().isTrue();
@@ -111,6 +111,32 @@ public class ValueAssertTest {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
                 "<fruit name=\"apple\" fresh=\"2\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean();
+    }
+
+    @Test
+    public void testAsBoolean_withZeroAsArgument_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <0>%nto be convertible to%n <boolean>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"0\"/>" +
+                "</fruits>";
+
+        assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean();
+    }
+
+    @Test
+    public void testAsBoolean_withOneAsArgument_shouldFailed() {
+
+        thrown.expectAssertionError("Expecting:%n <1>%nto be convertible to%n <boolean>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"1\"/>" +
                 "</fruits>";
 
         assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").asBoolean();
@@ -175,10 +201,10 @@ public class ValueAssertTest {
 
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
-                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"apple\" fresh=\"true\"/>" +
                 "<fruit name=\"orange\" fresh=\"false\"/>" +
-                "<fruit name=\"banana\" fresh=\"1\"/>" +
-                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "<fruit name=\"banana\" fresh=\"True\"/>" +
+                "<fruit name=\"pear\" fresh=\"False\"/>" +
                 "</fruits>";
 
         assertThat(xml).valueByXPath("//fruits/fruit[@name=\"apple\"]/@fresh").isEqualTo(true);

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
@@ -1,30 +1,82 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 package org.xmlunit.matchers;
 
 import org.hamcrest.Description;
+import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.math.BigDecimal;
 
+/**
+ * This Hamcrest {@link Matcher} is base Matcher to verify
+ * whether examined string value is convertible to the specified type
+ * and whether converted value corresponds to the given value valueMatcher.
+ * Examined string value can be evaluation of an XPath expression.
+ * <p>
+ * Currently {@link BigDecimal}, {@link Double}, {@link Integer} and {@link Boolean} types are supported.
+ *
+ * <p><b>Simple examples</b></p>
+ *
+ * <pre>
+ *     assertThat("3.0", asDouble(greaterThanOrEqualTo(2.0)));
+ *     assertThat("1.0e1", asBigDecimal(equalTo(BigDecimal.TEN)));
+ *     assertThat("3", asInt(lessThan(4)));
+ *     assertThat("false", asBoolean(equalTo(false)));
+ *     assertThat("1", asBoolean(equalTo(true)));
+ * </pre>
+ *
+ * <p><b>Examples with XPath evaluation</b></p>
+ *
+ * <pre>
+ *     String xml = "<fruits>" +
+ *             "<fruit name=\"apple\"/>" +
+ *             "<fruit name=\"orange\"/>" +
+ *             "<fruit name=\"banana\"/>" +
+ *             "<fruit name=\"pear\" fresh=\"0\"/>" +
+ *             "</fruits>";
+ *
+ *     assertThat(xml, hasXPath("count(//fruits/fruit)", asDouble(equalTo(4.0))));
+ *     assertThat(xml, hasXPath("count(//fruits/fruit)", asBigDecimal(greaterThan(BigDecimal.ONE))));
+ *     assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(lessThan(5))));
+ *     assertThat(xml, hasXPath("//fruits/fruit[@name=\"pear\"]/@fresh", asBoolean(equalTo(false))));
+ * </pre>
+ *
+ * @param <T> target type
+ * @since XMLUnit 2.6.2
+ */
 public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
     private T value;
     private Exception exception;
 
     private final Class<T> clazz;
-    private final Matcher<? extends T> matcher;
+    private final Matcher<? extends T> valueMatcher;
 
-    private TypeMatcher(Class<T> clazz, Matcher<? extends T> matcher) {
+    public TypeMatcher(Class<T> clazz, Matcher<? extends T> valueMatcher) {
         super(String.class);
         this.clazz = clazz;
-        this.matcher = matcher;
+        this.valueMatcher = valueMatcher;
     }
 
     @Override
     protected boolean matchesSafely(String item) {
         try {
             value = nullSafeConvert(item);
-            return matcher.matches(value);
+            return valueMatcher.matches(value);
         } catch (Exception e) {
             exception = e;
             return false;
@@ -33,19 +85,18 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText("string and converted to ")
+        description.appendText("string converted to ")
                 .appendText(clazz.getName())
                 .appendText(" ")
-                .appendDescriptionOf(matcher);
+                .appendDescriptionOf(valueMatcher);
     }
 
     @Override
     protected void describeMismatchSafely(String item, Description mismatchDescription) {
-        if(exception != null) {
+        if (exception != null) {
             mismatchDescription.appendText("failed with ")
                     .appendText(exception.toString());
-        }
-        else {
+        } else {
             mismatchDescription.appendText("was ")
                     .appendValue(value);
         }
@@ -64,20 +115,76 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
     protected abstract T convert(String item);
 
-    public static TypeMatcher<BigDecimal> asBigDecimal(Matcher<? extends BigDecimal> matcher) {
-        return new BigDecimalTypeMatcher(matcher);
+    /**
+     * Creates a matcher that matches when the examined string is convertible to {@link BigDecimal}
+     * and converted value satisfies the specified <code>valueMatcher</code>.
+     *
+     * <p>For example:</p>
+     * <pre>
+     *     assertThat("1.0e1", asBigDecimal(equalTo(BigDecimal.TEN)));
+     *     assertThat(xml, hasXPath("count(//fruits/fruit)", asBigDecimal(greaterThan(BigDecimal.ONE))));
+     * </pre>
+     *
+     * @param valueMatcher valueMatcher for the converted value
+     * @return the BigDecimal matcher
+     */
+    @Factory
+    public static TypeMatcher<BigDecimal> asBigDecimal(Matcher<? extends BigDecimal> valueMatcher) {
+        return new BigDecimalTypeMatcher(valueMatcher);
     }
 
-    public static TypeMatcher<Double> asDouble(Matcher<? extends Double> matcher) {
-        return new DoubleTypeMatcher(matcher);
+    /**
+     * Creates a matcher that matches when the examined string is convertible to {@link Double}
+     * and converted value satisfies the specified <code>valueMatcher</code>.
+     *
+     * <p>For example:</p>
+     * <pre>
+     *     assertThat("3.0", asDouble(greaterThanOrEqualTo(2.0)));
+     *     assertThat(xml, hasXPath("count(//fruits/fruit)", asDouble(equalTo(3.0))));
+     * </pre>
+     *
+     * @param valueMatcher valueMatcher for the converted value
+     * @return the Double matcher
+     */
+    @Factory
+    public static TypeMatcher<Double> asDouble(Matcher<? extends Double> valueMatcher) {
+        return new DoubleTypeMatcher(valueMatcher);
     }
 
-    public static TypeMatcher<Integer> asInt(Matcher<? extends Integer> matcher) {
-        return new IntegerTypeMatcher(matcher);
+    /**
+     * Creates a matcher that matches when the examined string is convertible to {@link Integer}
+     * and converted value satisfies the specified <code>valueMatcher</code>.
+     *
+     * <p>For example:</p>
+     * <pre>
+     *     assertThat("3", asInt(lessThan(4)));
+     *     assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(lessThan(4))));
+     * </pre>
+     *
+     * @param valueMatcher valueMatcher for the converted value
+     * @return the Integer matcher
+     */
+    @Factory
+    public static TypeMatcher<Integer> asInt(Matcher<? extends Integer> valueMatcher) {
+        return new IntegerTypeMatcher(valueMatcher);
     }
 
-    public static TypeMatcher<Boolean> asBoolean(Matcher<? extends Boolean> matcher) {
-        return new BooleanTypeMatcher(matcher);
+    /**
+     * Creates a matcher that matches when the examined string is convertible to {@link Boolean}
+     * and converted value satisfies the specified <code>valueMatcher</code>.
+     *
+     * <p>For example:</p>
+     * <pre>
+     *     assertThat("false", asBoolean(equalTo(false)));
+     *     assertThat(xml, hasXPath("//fruits/fruit[@name=\"apple\"]/@fresh", asBoolean(equalTo(true))));
+     * </pre>
+     *
+     * @param valueMatcher valueMatcher for the converted value
+     * @return the Boolean matcher
+     */
+    @Factory
+    public static TypeMatcher<Boolean> asBoolean(Matcher<? extends Boolean> valueMatcher) {
+        return new BooleanTypeMatcher(valueMatcher);
     }
 
     private static class BigDecimalTypeMatcher extends TypeMatcher<BigDecimal> {

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
@@ -8,6 +8,9 @@ import java.math.BigDecimal;
 
 public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
+    private T value;
+    private Exception exception;
+
     private final Class<T> clazz;
     private final Matcher<? extends T> matcher;
 
@@ -19,17 +22,36 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
     @Override
     protected boolean matchesSafely(String item) {
-        T value = convertSafe(item);
-        return matcher.matches(value);
+        try {
+            value = nullSafeConvert(item);
+            return matcher.matches(value);
+        } catch (Exception e) {
+            exception = e;
+            return false;
+        }
     }
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(" a string converted to ")
-                .appendText(clazz.getName());
+        description.appendText("string and converted to ")
+                .appendText(clazz.getName())
+                .appendText(" ")
+                .appendDescriptionOf(matcher);
     }
 
-    private T convertSafe(String item) {
+    @Override
+    protected void describeMismatchSafely(String item, Description mismatchDescription) {
+        if(exception != null) {
+            mismatchDescription.appendText("failed with ")
+                    .appendText(exception.toString());
+        }
+        else {
+            mismatchDescription.appendText("was ")
+                    .appendValue(value);
+        }
+    }
+
+    private T nullSafeConvert(String item) {
         if (item == null) {
             return null;
         }
@@ -52,6 +74,10 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
 
     public static TypeMatcher<Integer> asInt(Matcher<? extends Integer> matcher) {
         return new IntegerTypeMatcher(matcher);
+    }
+
+    public static TypeMatcher<Boolean> asBoolean(Matcher<? extends Boolean> matcher) {
+        return new BooleanTypeMatcher(matcher);
     }
 
     private static class BigDecimalTypeMatcher extends TypeMatcher<BigDecimal> {
@@ -87,6 +113,25 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
         @Override
         protected Integer convert(String item) {
             return Integer.valueOf(item);
+        }
+    }
+
+    private static class BooleanTypeMatcher extends TypeMatcher<Boolean> {
+
+        private BooleanTypeMatcher(Matcher<? extends Boolean> matcher) {
+            super(Boolean.class, matcher);
+        }
+
+        @Override
+        protected Boolean convert(String item) {
+            item = item.toLowerCase();
+            if (item.equals("1") || item.equals("true")) {
+                return true;
+            }
+            if (item.equals("0") || item.equals("false")) {
+                return false;
+            }
+            throw new IllegalArgumentException("\"" + item + "\" is not a boolean value");
         }
     }
 }

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
@@ -1,0 +1,92 @@
+package org.xmlunit.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.math.BigDecimal;
+
+public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
+
+    private final Class<T> clazz;
+    private final Matcher<? extends T> matcher;
+
+    private TypeMatcher(Class<T> clazz, Matcher<? extends T> matcher) {
+        super(String.class);
+        this.clazz = clazz;
+        this.matcher = matcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(String item) {
+        T value = convertSafe(item);
+        return matcher.matches(value);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(" a string converted to ")
+                .appendText(clazz.getName());
+    }
+
+    private T convertSafe(String item) {
+        if (item == null) {
+            return null;
+        }
+        item = item.trim();
+        if (item.length() < 1) {
+            return null;
+        }
+        return convert(item);
+    }
+
+    protected abstract T convert(String item);
+
+    public static TypeMatcher<BigDecimal> asBigDecimal(Matcher<? extends BigDecimal> matcher) {
+        return new BigDecimalTypeMatcher(matcher);
+    }
+
+    public static TypeMatcher<Double> asDouble(Matcher<? extends Double> matcher) {
+        return new DoubleTypeMatcher(matcher);
+    }
+
+    public static TypeMatcher<Integer> asInt(Matcher<? extends Integer> matcher) {
+        return new IntegerTypeMatcher(matcher);
+    }
+
+    private static class BigDecimalTypeMatcher extends TypeMatcher<BigDecimal> {
+
+        private BigDecimalTypeMatcher(Matcher<? extends BigDecimal> matcher) {
+            super(BigDecimal.class, matcher);
+        }
+
+        @Override
+        protected BigDecimal convert(String item) {
+            return new BigDecimal(item);
+        }
+    }
+
+    private static class DoubleTypeMatcher extends TypeMatcher<Double> {
+
+        private DoubleTypeMatcher(Matcher<? extends Double> matcher) {
+            super(Double.class, matcher);
+        }
+
+        @Override
+        protected Double convert(String item) {
+            return Double.valueOf(item);
+        }
+    }
+
+    private static class IntegerTypeMatcher extends TypeMatcher<Integer> {
+
+        private IntegerTypeMatcher(Matcher<? extends Integer> matcher) {
+            super(Integer.class, matcher);
+        }
+
+        @Override
+        protected Integer convert(String item) {
+            return Integer.valueOf(item);
+        }
+    }
+}

--- a/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
+++ b/xmlunit-matchers/src/main/java/org/xmlunit/matchers/TypeMatcher.java
@@ -36,7 +36,7 @@ import java.math.BigDecimal;
  *     assertThat("1.0e1", asBigDecimal(equalTo(BigDecimal.TEN)));
  *     assertThat("3", asInt(lessThan(4)));
  *     assertThat("false", asBoolean(equalTo(false)));
- *     assertThat("1", asBoolean(equalTo(true)));
+ *     assertThat("True", asBoolean(equalTo(true)));
  * </pre>
  *
  * <p><b>Examples with XPath evaluation</b></p>
@@ -46,7 +46,7 @@ import java.math.BigDecimal;
  *             "<fruit name=\"apple\"/>" +
  *             "<fruit name=\"orange\"/>" +
  *             "<fruit name=\"banana\"/>" +
- *             "<fruit name=\"pear\" fresh=\"0\"/>" +
+ *             "<fruit name=\"pear\" fresh=\"false\"/>" +
  *             "</fruits>";
  *
  *     assertThat(xml, hasXPath("count(//fruits/fruit)", asDouble(equalTo(4.0))));
@@ -232,10 +232,10 @@ public abstract class TypeMatcher<T> extends TypeSafeMatcher<String> {
         @Override
         protected Boolean convert(String item) {
             item = item.toLowerCase();
-            if (item.equals("1") || item.equals("true")) {
+            if (item.equals("true")) {
                 return true;
             }
-            if (item.equals("0") || item.equals("false")) {
+            if (item.equals("false")) {
                 return false;
             }
             throw new IllegalArgumentException("\"" + item + "\" is not a boolean value");

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
@@ -1,22 +1,30 @@
 package org.xmlunit.matchers;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
 import static org.xmlunit.matchers.TypeMatcher.asBigDecimal;
+import static org.xmlunit.matchers.TypeMatcher.asBoolean;
 import static org.xmlunit.matchers.TypeMatcher.asDouble;
 import static org.xmlunit.matchers.TypeMatcher.asInt;
 
 public class TypeMatcherTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
-    public void testXPathCountAsType() throws Exception {
+    public void testXPathCountAsType() {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
                 "<fruit name=\"apple\"/>" +
@@ -27,5 +35,117 @@ public class TypeMatcherTest {
         assertThat(xml, hasXPath("count(//fruits/fruit)", asDouble(equalTo(3.0))));
         assertThat(xml, hasXPath("count(//fruits/fruit)", asBigDecimal(greaterThan(BigDecimal.ONE))));
         assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(lessThan(4))));
+    }
+
+    @Test
+    public void createUsefulMessageWhenAsDoubleFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
+                "string and converted to java.lang.Double <3.0>");
+        thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits><fruit name=\"apple\"/></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit/@name", asDouble(equalTo(3.0))));
+    }
+
+    @Test
+    public void createUsefulMessageWhenAsBigDecimalFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
+                "string and converted to java.math.BigDecimal <10>");
+        thrown.expectMessage("failed with java.lang.NumberFormatException");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits><fruit name=\"apple\"/></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit/@name", asBigDecimal(equalTo(BigDecimal.TEN))));
+    }
+
+    @Test
+    public void createUsefulMessageWhenAsIntFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
+                "string and converted to java.lang.Integer <3>");
+        thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits><fruit name=\"apple\"/></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit/@name", asInt(equalTo(3))));
+    }
+
+    @Test
+    public void createUsefulMessageWhenAsBooleanFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
+                "string and converted to java.lang.Boolean <false>");
+        thrown.expectMessage("failed with java.lang.IllegalArgumentException: \"apple\" is not a boolean value");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits><fruit name=\"apple\"/></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit/@name", asBoolean(equalTo(false))));
+    }
+
+    @Test
+    public void createUsefulMessageWhenEqualToFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("XML with XPath count(//fruits/fruit) evaluated to " +
+                "string and converted to java.lang.Integer <2>");
+        thrown.expectMessage("was <1>");
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "</fruits>";
+
+        assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(equalTo(2))));
+    }
+
+    @Test
+    public void testAsTypeWithNegation() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits><fruit name=\"apple\"/></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit/@name", not(asDouble(equalTo(3.0)))));
+        assertThat(xml, hasXPath("//fruits/fruit/@name", not(asBigDecimal(equalTo(BigDecimal.TEN)))));
+        assertThat(xml, hasXPath("//fruits/fruit/@name", not(asInt(equalTo(3)))));
+        assertThat(xml, hasXPath("//fruits/fruit/@name", not(asBoolean(equalTo(false)))));
+    }
+
+    @Test
+    public void testAsBoolean() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"orange\" fresh=\"false\"/>" +
+                "<fruit name=\"banana\" fresh=\"1\"/>" +
+                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "</fruits>";
+
+        assertThat(xml, hasXPath("//fruits/fruit[@name=\"apple\"]/@fresh", asBoolean(equalTo(true))));
+        assertThat(xml, hasXPath("//fruits/fruit[@name=\"orange\"]/@fresh", asBoolean(equalTo(false))));
+        assertThat(xml, hasXPath("//fruits/fruit[@name=\"banana\"]/@fresh", asBoolean(equalTo(true))));
+        assertThat(xml, hasXPath("//fruits/fruit[@name=\"pear\"]/@fresh", asBoolean(equalTo(false))));
+    }
+
+    @Test
+    public void testAsTypeWhenEvaluatedValueIsEmpty() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits></fruits>";
+
+        assertThat(xml, hasXPath("//fruits/@text", asDouble(nullValue(Double.class))));
+        assertThat(xml, hasXPath("//fruits/@text", asBigDecimal(nullValue(BigDecimal.class))));
+        assertThat(xml, hasXPath("//fruits/@text", asInt(nullValue(Integer.class))));
+        assertThat(xml, hasXPath("//fruits/@text", asBoolean(nullValue(Boolean.class))));
     }
 }

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
@@ -56,7 +56,7 @@ public class TypeMatcherTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
-                "string and converted to java.lang.Double <3.0>");
+                "string converted to java.lang.Double <3.0>");
         thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
 
         String xml = "<fruits><fruit name=\"apple\"/></fruits>";
@@ -69,7 +69,7 @@ public class TypeMatcherTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
-                "string and converted to java.math.BigDecimal <10>");
+                "string converted to java.math.BigDecimal <10>");
         thrown.expectMessage("failed with java.lang.NumberFormatException");
 
         String xml = "<fruits><fruit name=\"apple\"/></fruits>";
@@ -82,7 +82,7 @@ public class TypeMatcherTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
-                "string and converted to java.lang.Integer <3>");
+                "string converted to java.lang.Integer <3>");
         thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
 
         String xml = "<fruits><fruit name=\"apple\"/></fruits>";
@@ -95,7 +95,7 @@ public class TypeMatcherTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("XML with XPath //fruits/fruit/@name evaluated to " +
-                "string and converted to java.lang.Boolean <false>");
+                "string converted to java.lang.Boolean <false>");
         thrown.expectMessage("failed with java.lang.IllegalArgumentException: \"apple\" is not a boolean value");
 
         String xml = "<fruits><fruit name=\"apple\"/></fruits>";
@@ -108,7 +108,7 @@ public class TypeMatcherTest {
 
         thrown.expect(AssertionError.class);
         thrown.expectMessage("XML with XPath count(//fruits/fruit) evaluated to " +
-                "string and converted to java.lang.Integer <2>");
+                "string converted to java.lang.Integer <2>");
         thrown.expectMessage("was <1>");
 
         String xml = "<fruits><fruit name=\"apple\"/></fruits>";

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
@@ -1,3 +1,17 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 package org.xmlunit.matchers;
 
 import org.junit.Rule;
@@ -8,6 +22,7 @@ import java.math.BigDecimal;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
@@ -25,8 +40,7 @@ public class TypeMatcherTest {
 
     @Test
     public void testXPathCountAsType() {
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits>" +
+        String xml = "<fruits>" +
                 "<fruit name=\"apple\"/>" +
                 "<fruit name=\"orange\"/>" +
                 "<fruit name=\"banana\"/>" +
@@ -45,8 +59,7 @@ public class TypeMatcherTest {
                 "string and converted to java.lang.Double <3.0>");
         thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits><fruit name=\"apple\"/></fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit/@name", asDouble(equalTo(3.0))));
     }
@@ -59,8 +72,7 @@ public class TypeMatcherTest {
                 "string and converted to java.math.BigDecimal <10>");
         thrown.expectMessage("failed with java.lang.NumberFormatException");
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits><fruit name=\"apple\"/></fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit/@name", asBigDecimal(equalTo(BigDecimal.TEN))));
     }
@@ -73,8 +85,7 @@ public class TypeMatcherTest {
                 "string and converted to java.lang.Integer <3>");
         thrown.expectMessage("failed with java.lang.NumberFormatException: For input string: \"apple\"");
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits><fruit name=\"apple\"/></fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit/@name", asInt(equalTo(3))));
     }
@@ -87,8 +98,7 @@ public class TypeMatcherTest {
                 "string and converted to java.lang.Boolean <false>");
         thrown.expectMessage("failed with java.lang.IllegalArgumentException: \"apple\" is not a boolean value");
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits><fruit name=\"apple\"/></fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit/@name", asBoolean(equalTo(false))));
     }
@@ -101,10 +111,7 @@ public class TypeMatcherTest {
                 "string and converted to java.lang.Integer <2>");
         thrown.expectMessage("was <1>");
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits>" +
-                "<fruit name=\"apple\"/>" +
-                "</fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(equalTo(2))));
     }
@@ -112,8 +119,7 @@ public class TypeMatcherTest {
     @Test
     public void testAsTypeWithNegation() {
 
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits><fruit name=\"apple\"/></fruits>";
+        String xml = "<fruits><fruit name=\"apple\"/></fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit/@name", not(asDouble(equalTo(3.0)))));
         assertThat(xml, hasXPath("//fruits/fruit/@name", not(asBigDecimal(equalTo(BigDecimal.TEN)))));
@@ -140,12 +146,21 @@ public class TypeMatcherTest {
 
     @Test
     public void testAsTypeWhenEvaluatedValueIsEmpty() {
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                "<fruits></fruits>";
+        String xml = "<fruits></fruits>";
 
         assertThat(xml, hasXPath("//fruits/@text", asDouble(nullValue(Double.class))));
         assertThat(xml, hasXPath("//fruits/@text", asBigDecimal(nullValue(BigDecimal.class))));
         assertThat(xml, hasXPath("//fruits/@text", asInt(nullValue(Integer.class))));
         assertThat(xml, hasXPath("//fruits/@text", asBoolean(nullValue(Boolean.class))));
+    }
+
+    @Test
+    public void testAsTypeWithExplicitTestValues() {
+
+        assertThat("3.0", asDouble(greaterThanOrEqualTo(2.0)));
+        assertThat("1.0e1", asBigDecimal(equalTo(BigDecimal.TEN)));
+        assertThat("3", asInt(lessThan(4)));
+        assertThat("false", asBoolean(equalTo(false)));
+        assertThat("1", asBoolean(equalTo(true)));
     }
 }

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
@@ -132,10 +132,10 @@ public class TypeMatcherTest {
 
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                 "<fruits>" +
-                "<fruit name=\"apple\" fresh=\"True\"/>" +
+                "<fruit name=\"apple\" fresh=\"true\"/>" +
                 "<fruit name=\"orange\" fresh=\"false\"/>" +
-                "<fruit name=\"banana\" fresh=\"1\"/>" +
-                "<fruit name=\"pear\" fresh=\"0\"/>" +
+                "<fruit name=\"banana\" fresh=\"True\"/>" +
+                "<fruit name=\"pear\" fresh=\"False\"/>" +
                 "</fruits>";
 
         assertThat(xml, hasXPath("//fruits/fruit[@name=\"apple\"]/@fresh", asBoolean(equalTo(true))));
@@ -161,6 +161,26 @@ public class TypeMatcherTest {
         assertThat("1.0e1", asBigDecimal(equalTo(BigDecimal.TEN)));
         assertThat("3", asInt(lessThan(4)));
         assertThat("false", asBoolean(equalTo(false)));
+        assertThat("true", asBoolean(equalTo(true)));
+    }
+
+    @Test
+    public void conversionZeroValueToBooleanShouldFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("string converted to java.lang.Boolean <false>");
+        thrown.expectMessage("failed with java.lang.IllegalArgumentException: \"0\" is not a boolean value");
+
+        assertThat("0", asBoolean(equalTo(false)));
+    }
+
+    @Test
+    public void conversionOneValueToBooleanShouldFailed() {
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("string converted to java.lang.Boolean <true>");
+        thrown.expectMessage("failed with java.lang.IllegalArgumentException: \"1\" is not a boolean value");
+
         assertThat("1", asBoolean(equalTo(true)));
     }
 }

--- a/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
+++ b/xmlunit-matchers/src/test/java/org/xmlunit/matchers/TypeMatcherTest.java
@@ -1,0 +1,31 @@
+package org.xmlunit.matchers;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+import static org.xmlunit.matchers.TypeMatcher.asBigDecimal;
+import static org.xmlunit.matchers.TypeMatcher.asDouble;
+import static org.xmlunit.matchers.TypeMatcher.asInt;
+
+public class TypeMatcherTest {
+
+    @Test
+    public void testXPathCountAsType() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<fruits>" +
+                "<fruit name=\"apple\"/>" +
+                "<fruit name=\"orange\"/>" +
+                "<fruit name=\"banana\"/>" +
+                "</fruits>";
+
+        assertThat(xml, hasXPath("count(//fruits/fruit)", asDouble(equalTo(3.0))));
+        assertThat(xml, hasXPath("count(//fruits/fruit)", asBigDecimal(greaterThan(BigDecimal.ONE))));
+        assertThat(xml, hasXPath("count(//fruits/fruit)", asInt(lessThan(4))));
+    }
+}


### PR DESCRIPTION
TypeMatcher allows to check if an examined string value can be converted to specified type and perform matching on the converted value.
For now 4 types are support: BigDecimal, Double, Integer and Boolean
This feature is response on #133 and works well with `EvaluateXPathMatcher`:
```java
assertThat(xml, hasXPath("count(//fruits/fruit)", asBigDecimal(is(greaterThan(BigDecimal.ONE)))));
```
