### PR TITLE
add support for matchesRegex placeholder

### DIFF
--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IgnorePlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IgnorePlaceholderHandler.java
@@ -34,7 +34,7 @@ public class IgnorePlaceholderHandler implements PlaceholderHandler {
     }
 
     @Override
-    public ComparisonResult evaluate(String testText) {
+    public ComparisonResult evaluate(String testText, String... param) {
         return ComparisonResult.EQUAL;
     }
 }

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsNumberPlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsNumberPlaceholderHandler.java
@@ -33,7 +33,7 @@ public class IsNumberPlaceholderHandler implements PlaceholderHandler {
     }
 
     @Override
-    public ComparisonResult evaluate(String testText) {
+    public ComparisonResult evaluate(String testText, String... param) {
         return testText != null && testText.trim().matches(NUMBER_PATTERN) ? EQUAL : DIFFERENT;
     }
 }

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/MatchesRegexPlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/MatchesRegexPlaceholderHandler.java
@@ -1,0 +1,43 @@
+package org.xmlunit.placeholder;
+
+import org.xmlunit.XMLUnitException;
+import org.xmlunit.diff.ComparisonResult;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static org.xmlunit.diff.ComparisonResult.DIFFERENT;
+import static org.xmlunit.diff.ComparisonResult.EQUAL;
+
+/**
+ * Handler for the {@code matchesRegex()} placeholder keyword.
+ */
+public class MatchesRegexPlaceholderHandler implements PlaceholderHandler {
+    private static final String PLACEHOLDER_NAME = "matchesRegex";
+
+    @Override
+    public String getKeyword() {
+        return PLACEHOLDER_NAME;
+    }
+
+    @Override
+    public ComparisonResult evaluate(String testText, String... param) {
+        if (param.length > 0 && param[0] != null && !param[0].equals("")) {
+            try {
+                Pattern pattern = Pattern.compile(param[0].trim());
+                if (testText != null && evaluate(testText.trim(), pattern)) {
+                    return EQUAL;
+                }
+            } catch(PatternSyntaxException e) {
+                throw new XMLUnitException(e.getMessage(), e);
+            }
+        }
+        return DIFFERENT;
+    }
+
+    private boolean evaluate(String testText, Pattern pattern) {
+        Matcher matcher = pattern.matcher(testText);
+        return matcher.find();
+    }
+}

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/PlaceholderDifferenceEvaluator.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/PlaceholderDifferenceEvaluator.java
@@ -243,10 +243,23 @@ public class PlaceholderDifferenceEvaluator implements DifferenceEvaluator {
     }
 
     private boolean isKnown(String keyword) {
-        return KNOWN_HANDLERS.containsKey(keyword);
+        // extract placeholder name if parameters present
+        Pattern pattern = Pattern.compile("(\\w+)\\(?");
+        Matcher matcher = pattern.matcher(keyword);
+        if (matcher.find()) {
+            return KNOWN_HANDLERS.containsKey(matcher.group(1));
+        }
+        return false;
     }
 
     private ComparisonResult evaluate(String keyword, String testText) {
-        return KNOWN_HANDLERS.get(keyword).evaluate(testText);
+        Pattern pattern = Pattern.compile("^(\\w+)(?:\\((.+)\\))?$");
+        Matcher matcher = pattern.matcher(keyword);
+        String placeholderParam = "";
+        if (matcher.find()) {
+            keyword = matcher.group(1);
+            placeholderParam = matcher.group(2);
+        }
+        return KNOWN_HANDLERS.get(keyword).evaluate(testText, placeholderParam);
     }
 }

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/PlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/PlaceholderHandler.java
@@ -36,5 +36,5 @@ public interface PlaceholderHandler {
      * Evaluate the test value when control contained the placeholder
      * handled by this class.
      */
-    ComparisonResult evaluate(String testText);
+    ComparisonResult evaluate(String testText, String... placeholderParameters);
 }

--- a/xmlunit-placeholders/src/main/resources/META-INF/services/org.xmlunit.placeholder.PlaceholderHandler
+++ b/xmlunit-placeholders/src/main/resources/META-INF/services/org.xmlunit.placeholder.PlaceholderHandler
@@ -1,2 +1,3 @@
 org.xmlunit.placeholder.IgnorePlaceholderHandler
 org.xmlunit.placeholder.IsNumberPlaceholderHandler
+org.xmlunit.placeholder.MatchesRegexPlaceholderHandler

--- a/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/MatchesRegexPlaceholderHandlerTest.java
+++ b/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/MatchesRegexPlaceholderHandlerTest.java
@@ -1,0 +1,88 @@
+/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package org.xmlunit.placeholder;
+
+import org.junit.Test;
+import org.xmlunit.diff.ComparisonResult;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class MatchesRegexPlaceholderHandlerTest {
+
+    private PlaceholderHandler placeholderHandler = new MatchesRegexPlaceholderHandler();
+
+    @Test
+    public void shouldGetKeyword() {
+        String expected = "matchesRegex";
+        String keyword = placeholderHandler.getKeyword();
+
+        assertThat(keyword, equalTo(expected));
+    }
+
+    @Test
+    public void shouldEvaluateGivenSimpleRegex() {
+        String testTest = "1234";
+        String regex = "^\\d+$";
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.EQUAL));
+    }
+
+    @Test
+    public void shouldNotEvaluateGivenNull() {
+        String testTest = null;
+        String regex = "^\\d+$";
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.DIFFERENT));
+    }
+
+    @Test
+    public void shouldNotEvaluateGivenEmptyString() {
+        String testTest = "";
+        String regex = "^\\d+$";
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.DIFFERENT));
+    }
+
+    @Test
+    public void shouldNotEvaluateStringDoesNotMatchRegex() {
+        String testTest = "not parsable as a number even though it contains 123 numbers";
+        String regex = "^\\d+$";
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.DIFFERENT));
+    }
+
+    @Test
+    public void shouldNotEvaluateWithNullRegex() {
+        String testTest = "a string";
+        String regex = null;
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.DIFFERENT));
+    }
+
+    @Test
+    public void shouldNotEvaluateWithEmptyRegex() {
+        String testTest = "a string";
+        String regex = "";
+        ComparisonResult comparisonResult = placeholderHandler.evaluate(testTest, regex);
+
+        assertThat(comparisonResult, equalTo(ComparisonResult.DIFFERENT));
+    }
+
+}


### PR DESCRIPTION
Introduce the implementation of matchesRegex placeholders. Need that functionality on the project I am working on. I decided to share my implementation with you as a PR
Since this placeholder contains a parameter I had to extend the signature of `evaluate` method to support parameters as optional array of strings. 