### PR TITLE
Update assertj+tests work with other locales

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.0</version>
         <inherited>false</inherited>
         <configuration>
           <descriptorRefs>
@@ -505,7 +505,7 @@
           <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>2.9.0</version>
+            <version>3.15.0</version>
           </dependency>
           <dependency>
             <groupId>net.bytebuddy</groupId>

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/LocaleModifier.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/LocaleModifier.java
@@ -1,0 +1,16 @@
+package org.xmlunit.assertj;
+
+import java.util.Locale;
+
+public class LocaleModifier {
+    private Locale locale;
+
+    public void setEnglish() {
+        locale = Locale.getDefault();
+        Locale.setDefault(new Locale("en"));
+    }
+
+    public void restore() {
+        Locale.setDefault(locale);
+    }
+}

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -21,12 +21,13 @@ import org.mockito.Mockito;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPathFactory;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -13,19 +13,20 @@
 */
 package org.xmlunit.assertj;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
@@ -33,6 +34,18 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 public class ValueAssertTest {
     @Rule
     public ExpectedException thrown = none();
+
+    private static LocaleModifier locale = new LocaleModifier();
+
+    @BeforeClass
+    public static void overwriteLocale() {
+        locale.setEnglish();
+    }
+
+    @AfterClass
+    public static void restoreLocale() {
+        locale.restore();
+    }
 
     @Test
     public void testAsInt_shouldPass() {

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
@@ -19,10 +19,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.xmlunit.validation.Languages;
 
+import java.io.File;
+
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import java.io.File;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValidationTest.java
@@ -13,15 +13,16 @@
 */
 package org.xmlunit.assertj;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.xmlunit.validation.Languages;
 
-import java.io.File;
-
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import java.io.File;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
@@ -30,6 +31,18 @@ public class XmlAssertValidationTest {
 
     @Rule
     public ExpectedException thrown = none();
+
+    private static LocaleModifier locale = new LocaleModifier();
+
+    @BeforeClass
+    public static void overwriteLocale() {
+        locale.setEnglish();
+    }
+
+    @AfterClass
+    public static void restoreLocale() {
+        locale.restore();
+    }
 
     @Test
     public void testIsValidAgainst_shouldPass() {
@@ -89,7 +102,8 @@ public class XmlAssertValidationTest {
         StreamSource xml = new StreamSource(new File("../test-resources/BookXsdGenerated.xml"));
 
         assertThat(xml).isValidAgainst();
-        assertThat(xml).isValidAgainst(new Object[0]);
+        final Object[] emptyArray = new Object[0];
+        assertThat(xml).isValidAgainst(emptyArray);
     }
 
     @Test

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValueByXPathTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/XmlAssertValueByXPathTest.java
@@ -13,6 +13,8 @@
 */
 package org.xmlunit.assertj;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,6 +26,18 @@ public class XmlAssertValueByXPathTest {
 
     @Rule
     public ExpectedException thrown = none();
+
+    private static LocaleModifier locale = new LocaleModifier();
+
+    @BeforeClass
+    public static void overwriteLocale() {
+        locale.setEnglish();
+    }
+
+    @AfterClass
+    public static void restoreLocale() {
+        locale.restore();
+    }
 
     @Test
     public void testValueByXPath_withNull_shouldFailed() {


### PR DESCRIPTION
Dependencies updated:
- maven-assembly-plugin 3.0.0 -> 3.2.0 (bogus warning)
- assert 2.9.0 -> 3.15.0

AssertJ Unittests run on other locales
- Some Tests expect Messages in english, and running them on other locales
  won't work. So the test-classes set the locale to english before the tests
  and restore them after the tests


