### PR TITLE
Use Jakarta XML Binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
     <!-- 2.20.1 works for Java6 but not for Java 10 - for 2.21.0
          things are reversed -->
     <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
+
+    <!-- Jakarta XML Binding version -->
+    <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
   </properties>
 
   <inceptionYear>2001</inceptionYear>
@@ -100,9 +103,14 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>${jakarta.xml.bind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>${jakarta.xml.bind.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -145,22 +153,6 @@
         <artifactId>mockito-core</artifactId>
         <version>2.1.0</version>
         <scope>test</scope>
-      </dependency>
-      <!-- needed during tests when running on Java9+ -->
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-core</artifactId>
-        <version>2.3.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>2.3.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/xmlunit-core/pom.xml
+++ b/xmlunit-core/pom.xml
@@ -63,22 +63,13 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-core</artifactId>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>javax.activation</groupId>
-          <artifactId>activation</artifactId>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <scope>runtime</scope>
           <optional>true</optional>
         </dependency>
       </dependencies>


### PR DESCRIPTION
JAXB project has been moved into the Eclipse Jakarta project, and the maven coordinates have been changed. The migration has been followed already by several project (Eg. spring-boot), which is causing duplicate classes coming from different dependency jars.

Changes:

- Added the Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:2.3.3) and runtime (org.glassfish.jaxb:jaxb-runtime:2.3.3) to the Java 9+ profiled builds

- Removed the Old JAXB API and runtimes

- Removed from the pom.xml the javax.activation:activation:1.1.1 dependency, because the JAXB API defines this dependency as jakarta.activation:jakarta.activation-api:1.2.2. Due to this **Java Activation Framework has become a new transitive dependency of XMLUnit**, but it is compile dependency of the JAXB API, so it would be needed anyway somewhere to make XMLUnit work, at least the dependency is now explicit. I guess this did not caused any problem so far because the JAXB runtime transitively included it.

- The JAXB runtime is now a runtime scoped dependency (it is still optional, because others might use another implementation).

- The "jakarta.xml.bind.version" maven property has been introduced to enforce consistency of the API and runtime dependencies.
