### PR TITLE
Adjust ValueAssertTest for changed format of mismatched string exception

### DIFF
--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/ValueAssertTest.java
@@ -24,6 +24,7 @@ import org.xmlunit.assertj.util.SetEnglishLocaleRule;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -263,7 +264,13 @@ public class ValueAssertTest {
     @Test
     public void testIsEqualTo_withAttributeValueExpression_shouldFailed() {
 
-        thrown.expectAssertionError("expected:<\"[something]\"> but was:<\"[abc]\">");
+        thrown.expectAssertionErrorPattern(".*("
+            // AssertJ since "forever"
+            + Pattern.quote("expected:<\"[something]\"> but was:<\"[abc]\">")
+            + "|"
+            // AssertJ 3.19.0+
+            + Pattern.quote("Expecting:\n <\"abc\">\nto be equal to:\n <\"something\">\nbut was not.")
+            + ")");
 
         String xml = "<a><b attr=\"abc\"></b></a>";
 


### PR DESCRIPTION
This fix is required when building the `xmlunit` [package](https://src.fedoraproject.org/rpms/xmlunit) for recent versions of Fedora.

It also corresponds to the exception message format that should be generated by the `xmlunit` code: https://github.com/xmlunit/xmlunit/blob/5b66f10fb5d43c21c5aac6ad725c1925e7abddd2/xmlunit-assertj/src/main/java/org/xmlunit/assertj/error/ComparisonFailureErrorFactory.java#L31

However, running the tests directly using `mvn clean test` fail with this fix because the old format exception message is returned. (Unfortunately, I don't know Java well enough to be able to explain why!)