### PR TITLE
Issue 232 diff tostring refactoring

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/diff/Diff.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/diff/Diff.java
@@ -15,6 +15,7 @@
 package org.xmlunit.diff;
 
 import javax.xml.transform.Source;
+import java.util.Iterator;
 
 /**
  * The Diff-Object is the result of two comparisons.
@@ -81,7 +82,15 @@ public class Diff {
         if (!hasDifferences()) {
             return "[identical]";
         }
-        return getDifferences().iterator().next().getComparison().toString(formatter);
+        Iterator<Difference> diffIterator = getDifferences().iterator();
+        StringBuilder result = new StringBuilder()
+            .append(diffIterator.next().getComparison().toString(formatter));
+        String lineSeparator = System.lineSeparator();
+        while (diffIterator.hasNext()) {
+            result.append(lineSeparator)
+                .append(diffIterator.next().getComparison().toString(formatter));
+        }
+        return result.toString();
     }
 
 }


### PR DESCRIPTION
Related to [Issue 232](https://github.com/xmlunit/xmlunit/issues/232)

Change the behavior of `Diff.toString()` method - return string representations of all failed comparisons insted of only first one.
Also fixed some typos.

Sorry for not adding any tests. I have looked to `DiffBuilderTest` and didn't found any test which would assert fail message. All of them just checked the difference existance.