### PR TITLE
Fix Jacoco report error when running against java 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.1</version>
+          <version>0.8.7</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
To resolve https://github.com/xmlunit/xmlunit/issues/273
Either we bump this, or add an additional clause on Java 8+ and Java 14+ profile with the 0.8.7 Jacoco.

How to test: mvn clean test jacoco:report  -Pjacoco,java14+ 