### PR TITLE
Travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,24 @@ language: java
 env: VERSION=2.10.1-SNAPSHOT
 matrix:
   include:
-    - dist: trusty
+    - dist: focal
       jdk: openjdk7
-    - dist: trusty
+    - dist: focal
       jdk: openjdk8
+    - dist: focal
+      jdk: openjdk10
     - dist: xenial
       jdk: openjdk11
-    - dist: trusty
-      jdk: oraclejdk8
-    - dist: trusty
-      jdk: oraclejdk9
-    - dist: trusty
-      jdk: openjdk10
-    - dist: trusty
-      jdk: oraclejdk11
-    - dist: bionic
+    - dist: focal
       jdk: openjdk14
-    - dist: bionic
+    - dist: focal
       jdk: openjdk17
+    - dist: focal
+      jdk: oraclejdk8
+    - dist: focal
+      jdk: oraclejdk9
+    - dist: focal
+      jdk: oraclejdk11
 addons:
   apt:
     update: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ matrix:
     - dist: trusty
       jdk: openjdk8
     - dist: xenial
-      jdk: openjdk10
-    - dist: xenial
       jdk: openjdk11
     - dist: trusty
       jdk: oraclejdk8
     - dist: trusty
       jdk: oraclejdk9
+    - dist: trusty
+      jdk: oraclejdk10
     - dist: trusty
       jdk: oraclejdk11
     - dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - dist: trusty
       jdk: oraclejdk9
     - dist: trusty
-      jdk: oraclejdk10
+      jdk: openjdk10
     - dist: trusty
       jdk: oraclejdk11
     - dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,21 @@ language: java
 env: VERSION=2.10.1-SNAPSHOT
 matrix:
   include:
-    - dist: focal
+    - dist: trusty
       jdk: openjdk7
     - dist: focal
       jdk: openjdk8
     - dist: focal
       jdk: openjdk10
-    - dist: xenial
+    - dist: focal
       jdk: openjdk11
     - dist: focal
       jdk: openjdk14
     - dist: focal
       jdk: openjdk17
-    - dist: focal
+    - dist: trusty
       jdk: oraclejdk8
-    - dist: focal
+    - dist: trusty
       jdk: oraclejdk9
     - dist: focal
       jdk: oraclejdk11

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
     <maven.jacoco.plugin.version>0.8.11</maven.jacoco.plugin.version>
     <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
+    <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
     <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
     <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
     <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
     <maven.jacoco.plugin.version>0.8.11</maven.jacoco.plugin.version>
     <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
-    <maven.javadoc.plugin.version>3.5.0</maven.javadoc.plugin.version>
+    <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
     <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
     <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
     <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>


### PR DESCRIPTION
1. Replace bionic with focal as `bionic` is being deprecated. (https://docs.travis-ci.com/user/reference/overview/)
2. Fix the build of JDK10 build by bumping the VM from `xenial` to `focal` as JDK10 is no longer available under `denial`.