### PR TITLE
Add the option to load a reader as an Unknown parameter

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/builder/Input.java
@@ -150,6 +150,8 @@ public class Input {
             xml = Input.fromChannel((ReadableByteChannel) object);
         } else if (object instanceof Path) {
             xml = Input.fromPath((Path) object);
+        } else if (object instanceof Reader) {
+            xml = Input.fromReader((Reader) object);
         } else {
             // assume it is a JaxB-Object.
             xml = Input.fromJaxb(object);

--- a/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/builder/InputTest.java
@@ -164,6 +164,10 @@ public class InputTest {
              FileChannel fc = is.getChannel()) {
             allIsWellFor(Input.from(fc).build());
         }
+        //from Reader
+        try (FileReader r = new FileReader(TestResources.ANIMAL_FILE)) {
+            allIsWellFor(Input.from(r).build());
+        }
         // from Path
         allIsWellFor(Input.from(new File(TestResources.ANIMAL_FILE).toPath()).build());
     }


### PR DESCRIPTION
It seems like the Unknown source parser was missing the case to parse from a reader, so I added it