### PR TITLE
add additional compatibility tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ jobs:
           command: ./assertj-test.sh ${VERSION} 3.20.2 both
       - run:
           working_directory: compat-tests
+          command: ./assertj-test.sh ${VERSION} 3.27.3 both
+      - run:
+          working_directory: compat-tests
           command: ./jaxb-test.sh ${VERSION} javax
       - run:
           working_directory: compat-tests
@@ -105,6 +108,9 @@ jobs:
       - run:
           working_directory: compat-tests
           command: ./hamcrest-test.sh ${VERSION} 2.2
+      - run:
+          working_directory: compat-tests
+          command: ./hamcrest3-test.sh ${VERSION} 3.0
 
 workflows:
   build-and-test:

--- a/compat-tests/hamcrest3-test.sh
+++ b/compat-tests/hamcrest3-test.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$#" -ne 2 ]; then
-    echo "Usage: hamcrest-test.sh XMLUNIT_VERSION HAMCREST_VERSION"
+    echo "Usage: hamcrest3-test.sh XMLUNIT_VERSION HAMCREST_VERSION"
     exit 1
 fi
 
@@ -50,13 +50,7 @@ cat > ${SCRATCH_DIR}/pom.xml <<EOF
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>\${hamcrest.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>\${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>

--- a/compat-tests/hamcrest3-test.sh
+++ b/compat-tests/hamcrest3-test.sh
@@ -46,6 +46,16 @@ cat > ${SCRATCH_DIR}/pom.xml <<EOF
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-library</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
see also #165 - the new test should ensure the matchers work with hamcrest 3.0 as well.