### PR TITLE
bump xmlunit-assertj3's AssertJ dependency to 3.27.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,19 +87,7 @@ jobs:
           command: ./assertj-test.sh ${VERSION} 3.9.1 only-assertj
       - run:
           working_directory: compat-tests
-          command: ./assertj-test.sh ${VERSION} 3.13.2 only-assertj
-      - run:
-          working_directory: compat-tests
-          command: ./assertj-test.sh ${VERSION} 3.15.0 only-assertj
-      - run:
-          working_directory: compat-tests
-          command: ./assertj-test.sh ${VERSION} 3.19.0 both
-      - run:
-          working_directory: compat-tests
-          command: ./assertj-test.sh ${VERSION} 3.20.2 both
-      - run:
-          working_directory: compat-tests
-          command: ./assertj-test.sh ${VERSION} 3.27.3 both
+          command: ./assertj-test.sh ${VERSION} 3.27.6 only-assertj
       - run:
           working_directory: compat-tests
           command: ./jaxb-test.sh ${VERSION} javax

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,17 @@
 
 ## XMLUnit for Java 2.11.1 - /not released, yet/
 
+* bumped xmlunit-assertj3's dependency on assert to 3.27.6.
+
+  This is to make people aware of
+  https://github.com/assertj/assertj/security/advisories/GHSA-rqfh-9r24-8c9r
+
+  XMLUnit itself does not use the affected code in AssertJ so the upgrade is not strictly necessary - and this is why
+  the xmlunit-assertj module is not updated. In fact the assertions provided by xmlunit-assertj3 are the recommended
+  upgrade path for users of AssertJ 4.x.
+
+  PR [#320](https://github.com/xmlunit/xmlunit/pull/320)
+
 ## XMLUnit for Java 2.11.0 - /Released 2025-10-24/
 
 * the `xmlunit-jakarta-jaxb-impl` no longer depends on `org.glassfish.jaxb:jaxb-runtime` directly.

--- a/xmlunit-assertj3/pom.xml
+++ b/xmlunit-assertj3/pom.xml
@@ -26,7 +26,7 @@
     <automatic.module.name>${project.groupId}.assertj3</automatic.module.name>
     <maven.compile.source>8</maven.compile.source>
     <maven.compile.target>8</maven.compile.target>
-    <assertj3.version>3.18.1</assertj3.version>
+    <assertj3.version>3.27.6</assertj3.version>
   </properties>
 
   <artifactId>xmlunit-assertj3</artifactId>


### PR DESCRIPTION
This is to make people aware of
https://github.com/assertj/assertj/security/advisories/GHSA-rqfh-9r24-8c9r

XMLUnit itself does not use the affected code in AssertJ so the upgrade is not strictly necessary - and this is why the xmlunit-assertj module is not updated. In fact the assertions provided by xmlunit-assertj3 are the recommended upgrade path for users of AssertJ 4.x.