### PR TITLE
introduce DefaultWithDTDParsing configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,9 +17,11 @@
 * actually made `withDTDParsingDisabled` do what it says.
 
   This is a bugfix and in a way it is backwards incompatible as it changes default behavior in a way that I intended to
-  do with XMLUnit 2.6.0 eight years ago.
+  do with XMLUnit 2.6.0 eight years ago. `DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing` provides the
+  behavior of XMLUnit 2.6.0 to 2.11.0.
 
   PRs [#326](https://github.com/xmlunit/xmlunit/pull/326) by [@jmestwa-coder](https://github.com/jmestwa-coder)
+  and [#328](https://github.com/xmlunit/xmlunit/pull/328)
 
 ## XMLUnit for Java 2.11.0 - /Released 2025-10-24/
 

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreIdenticalTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreIdenticalTest.java
@@ -28,6 +28,7 @@ import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.DifferenceEvaluator;
 import org.xmlunit.diff.DifferenceEvaluators;
 import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 import org.xmlunit.util.Predicate;
 
 import java.io.IOException;
@@ -86,7 +87,10 @@ public class CompareAssertAreIdenticalTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areIdentical();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areIdentical();
     }
 
     @Test
@@ -114,7 +118,10 @@ public class CompareAssertAreIdenticalTest {
 
         assertThat(testXml)
             .withFailMessage("Alarm alarm!")
-            .and(controlXml).areIdentical();
+            .and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areIdentical();
     }
 
     @Test

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreNotIdenticalTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreNotIdenticalTest.java
@@ -20,6 +20,9 @@ import org.xmlunit.diff.ComparisonListener;
 import org.xmlunit.diff.ComparisonResult;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
@@ -72,7 +75,10 @@ public class CompareAssertAreNotIdenticalTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areNotIdentical();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotIdentical();
     }
 
     @Test

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreNotSimilarTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreNotSimilarTest.java
@@ -16,8 +16,10 @@ package org.xmlunit.assertj;
 import org.junit.Rule;
 import org.junit.Test;
 import org.xmlunit.TestResources;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import java.io.File;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
@@ -79,7 +81,10 @@ public class CompareAssertAreNotSimilarTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areNotSimilar();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotSimilar();
     }
 
     @Test
@@ -100,8 +105,10 @@ public class CompareAssertAreNotSimilarTest {
                 "</a>";
 
         assertThat(testXml).and(controlXml)
-                .ignoreChildNodesOrder()
-                .areNotSimilar();
+            .ignoreChildNodesOrder()
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotSimilar();
     }
 
     @Test

--- a/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreSimilarTest.java
+++ b/xmlunit-assertj/src/test/java/org/xmlunit/assertj/CompareAssertAreSimilarTest.java
@@ -27,8 +27,10 @@ import org.xmlunit.diff.ComparisonType;
 import org.xmlunit.diff.Difference;
 import org.xmlunit.diff.DifferenceEvaluator;
 import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import java.io.File;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj.ExpectedException.none;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
@@ -62,7 +64,10 @@ public class CompareAssertAreSimilarTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areSimilar();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areSimilar();
     }
 
     @Test
@@ -81,8 +86,10 @@ public class CompareAssertAreSimilarTest {
                 "</a>";
 
         assertThat(testXml).and(controlXml)
-                .ignoreChildNodesOrder()
-                .areSimilar();
+            .ignoreChildNodesOrder()
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areSimilar();
     }
 
     @Test

--- a/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreIdenticalTest.java
+++ b/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreIdenticalTest.java
@@ -28,6 +28,7 @@ import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.DifferenceEvaluator;
 import org.xmlunit.diff.DifferenceEvaluators;
 import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 import org.xmlunit.util.Predicate;
 
 import java.io.IOException;
@@ -86,7 +87,10 @@ public class CompareAssertAreIdenticalTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areIdentical();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areIdentical();
     }
 
     @Test
@@ -114,6 +118,8 @@ public class CompareAssertAreIdenticalTest {
 
         assertThat(testXml)
             .withFailMessage("Alarm alarm!")
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
             .and(controlXml).areIdentical();
     }
 

--- a/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreNotIdenticalTest.java
+++ b/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreNotIdenticalTest.java
@@ -20,6 +20,9 @@ import org.xmlunit.diff.ComparisonListener;
 import org.xmlunit.diff.ComparisonResult;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj3.ExpectedException.none;
 import static org.xmlunit.assertj3.XmlAssert.assertThat;
@@ -72,7 +75,10 @@ public class CompareAssertAreNotIdenticalTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areNotIdentical();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotIdentical();
     }
 
     @Test

--- a/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreNotSimilarTest.java
+++ b/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreNotSimilarTest.java
@@ -16,8 +16,10 @@ package org.xmlunit.assertj3;
 import org.junit.Rule;
 import org.junit.Test;
 import org.xmlunit.TestResources;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import java.io.File;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj3.ExpectedException.none;
 import static org.xmlunit.assertj3.XmlAssert.assertThat;
@@ -79,7 +81,10 @@ public class CompareAssertAreNotSimilarTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areNotSimilar();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotSimilar();
     }
 
     @Test
@@ -100,8 +105,10 @@ public class CompareAssertAreNotSimilarTest {
                 "</a>";
 
         assertThat(testXml).and(controlXml)
-                .ignoreChildNodesOrder()
-                .areNotSimilar();
+            .ignoreChildNodesOrder()
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areNotSimilar();
     }
 
     @Test

--- a/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreSimilarTest.java
+++ b/xmlunit-assertj3/src/test/java/org/xmlunit/assertj3/CompareAssertAreSimilarTest.java
@@ -27,8 +27,10 @@ import org.xmlunit.diff.ComparisonType;
 import org.xmlunit.diff.Difference;
 import org.xmlunit.diff.DifferenceEvaluator;
 import org.xmlunit.diff.DifferenceEvaluators;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import java.io.File;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.xmlunit.assertj3.ExpectedException.none;
 import static org.xmlunit.assertj3.XmlAssert.assertThat;
@@ -62,7 +64,10 @@ public class CompareAssertAreSimilarTest {
                 "   </c>" +
                 "</a>";
 
-        assertThat(testXml).and(controlXml).areSimilar();
+        assertThat(testXml).and(controlXml)
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areSimilar();
     }
 
     @Test
@@ -81,8 +86,10 @@ public class CompareAssertAreSimilarTest {
                 "</a>";
 
         assertThat(testXml).and(controlXml)
-                .ignoreChildNodesOrder()
-                .areSimilar();
+            .ignoreChildNodesOrder()
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .areSimilar();
     }
 
     @Test

--- a/xmlunit-core/src/main/java/org/xmlunit/util/DocumentBuilderFactoryConfigurer.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/util/DocumentBuilderFactoryConfigurer.java
@@ -106,6 +106,17 @@ public class DocumentBuilderFactoryConfigurer {
         .build();
 
     /**
+     * A relaxed instance that allows DTD parsing but prohibits loading of external entities.
+     *
+     * @since XMLUnit 2.12.0
+     */
+    public static final DocumentBuilderFactoryConfigurer DefaultWithDTDParsing = builder()
+        .withDTDLoadingDisabled()
+        .withXIncludeAware(false)
+        .withExpandEntityReferences(false)
+        .build();
+
+    /**
      * Builder for a DocumentBuilderFactoryConfigurer.
      *
      * @since XMLUnit 2.6.0

--- a/xmlunit-core/src/test/java/org/xmlunit/diff/DOMDifferenceEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/diff/DOMDifferenceEngineTest.java
@@ -22,6 +22,7 @@ import org.xmlunit.TestResources;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 import org.xmlunit.util.Linqy;
 import org.xmlunit.util.Predicate;
 import org.junit.Before;
@@ -125,7 +126,9 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
     private Document doc;
 
     @Before public void createDoc() throws Exception {
-        doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        DocumentBuilderFactory factory = DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+            .configure(DocumentBuilderFactory.newInstance());
+        doc = factory.newDocumentBuilder()
             .newDocument();
     }
 
@@ -391,7 +394,9 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
                     + "\"" + TestResources.BOOK_DTD
                     + "\">"
                     + "<Book/>")
-                               .build());
+                               .build(),
+                DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                    .configure(DocumentBuilderFactory.newInstance()));
         assertEquals(wrapAndStop(ComparisonResult.DIFFERENT),
                      d.compareNodes(d1, new XPathContext(),
                                     d2, new XPathContext()));
@@ -471,7 +476,9 @@ public class DOMDifferenceEngineTest extends AbstractDifferenceEngineTest {
                     + "\"" + TestResources.BOOK_DTD
                     + "\">"
                     + "<Book/>")
-                               .build());
+                               .build(),
+                DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                    .configure(DocumentBuilderFactory.newInstance()));
         assertEquals(wrap(ComparisonResult.EQUAL),
                      d.compareNodes(d1, new XPathContext(),
                                     d2, new XPathContext()));

--- a/xmlunit-core/src/test/java/org/xmlunit/diff/DefaultComparisonFormatterTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/diff/DefaultComparisonFormatterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.util.Convert;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -446,13 +447,17 @@ public class DefaultComparisonFormatterTest {
     @Test
     public void testComparisonType_ATTR_VALUE_EXPLICITLY_SPECIFIED() {
         // prepare data
-        Diff diff = DiffBuilder.compare(
+        Diff diff = DiffBuilder
+            .compare(
                 "<?xml version=\"1.0\" ?>" +
                 "<!DOCTYPE root [<!ELEMENT root ANY><!ATTLIST root c CDATA #FIXED \"xxx\">]>" +
                 "<root/>")
                 .withTest("<?xml version=\"1.0\" ?>" +
                 "<!DOCTYPE root [<!ELEMENT root ANY><!ATTLIST root c CDATA #FIXED \"xxx\">]>" +
-                "<root c=\"xxx\"/>").build();
+                "<root c=\"xxx\"/>")
+            .withDocumentBuilderFactory(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+                .configure(DocumentBuilderFactory.newInstance()))
+            .build();
         assertPreRequirements(diff, ComparisonType.ATTR_VALUE_EXPLICITLY_SPECIFIED);
         Comparison firstDiff = diff.getDifferences().iterator().next().getComparison();
 

--- a/xmlunit-core/src/test/java/org/xmlunit/diff/DifferenceEvaluatorsTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/diff/DifferenceEvaluatorsTest.java
@@ -16,9 +16,11 @@ package org.xmlunit.diff;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.transform.Source;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.Test;
 import org.xmlunit.builder.Input;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.CoreMatchers.is;
@@ -487,7 +489,8 @@ public class DifferenceEvaluatorsTest {
                                      boolean ignoreDoctypeDeclarationAsWell) {
         Source control = Input.from(controlXml) .build();
         Source test = Input.from(testXml) .build();
-        DOMDifferenceEngine e = new DOMDifferenceEngine();
+        DOMDifferenceEngine e = new DOMDifferenceEngine(DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+           .configure(DocumentBuilderFactory.newInstance()));
         if (ignoreDoctypeDeclarationAsWell) {
             e.setDifferenceEvaluator(DifferenceEvaluators.ignorePrologDifferences());
         } else {

--- a/xmlunit-core/src/test/java/org/xmlunit/util/DocumentBuilderFactoryConfigurerTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/util/DocumentBuilderFactoryConfigurerTest.java
@@ -55,4 +55,13 @@ public class DocumentBuilderFactoryConfigurerTest {
             fail("expected DOCTYPE declaration to be rejected by Default");
         }
     }
+
+    @Test
+    public void defaultWithDtdParsingAcceptsDoctype() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactoryConfigurer.DefaultWithDTDParsing
+            .configure(DocumentBuilderFactory.newInstance());
+        if (!parses(factory)) {
+            fail("expected DOCTYPE declaration to be accepted by DefaultWithDTDParsing");
+        }
+    }
 }


### PR DESCRIPTION
extends #326 with a new DocumentBuilderFactoryConfigurer that allwow DTD parsing and use it to make tests pass.