### PR TITLE
disable external entities in ParsingValidator instance parsing

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
@@ -34,10 +34,20 @@ import org.xml.sax.helpers.DefaultHandler;
  * <p>Even though this implementation supports W3C Schema you
  * shouldn't use it for that language but rather use
  * JAXPValidator.</p>
+ *
+ * <p><strong>Security note:</strong> like the rest of the {@code
+ * validation} package this class does not disable external entities
+ * by default - that has been a conscious decision since XMLUnit 2.6.0.
+ * An instance document with a {@code DOCTYPE} that declares an external
+ * entity may therefore cause that entity to be resolved while it is
+ * validated. If you validate untrusted input use {@link
+ * #setDisableExternalEntities setDisableExternalEntities(true)} to
+ * forbid this.</p>
  */
 public class ParsingValidator extends Validator {
     private final String language;
     private String schemaURI;
+    private boolean disableExternalEntities;
 
     /**
      * Creates a validator for the given schema language.
@@ -69,6 +79,26 @@ public class ParsingValidator extends Validator {
      */
     protected String getSchemaURI() {
         return schemaURI;
+    }
+
+    /**
+     * Whether external general and parameter entities should be
+     * disabled when the instance document is parsed for validation.
+     *
+     * <p>The default is {@code false}, leaving external entities
+     * enabled as they have been since XMLUnit 2.6.0. Setting this to
+     * {@code true} turns off the {@code external-general-entities} and
+     * {@code external-parameter-entities} features on the parser, which
+     * closes the XXE vector when validating untrusted instances. The
+     * DTD or schema to validate against is still resolved through the
+     * internal entity resolver, so DTD and schema validation keep
+     * working.</p>
+     *
+     * @since XMLUnit 2.12.1
+     * @param disable whether to disable external entities
+     */
+    public void setDisableExternalEntities(boolean disable) {
+        disableExternalEntities = disable;
     }
 
     /**
@@ -104,7 +134,9 @@ public class ParsingValidator extends Validator {
         try {
             factory.setNamespaceAware(true);
             factory.setValidating(true);
-            disableExternalEntities(factory);
+            if (disableExternalEntities) {
+                restrictExternalEntities(factory);
+            }
             SAXParser parser = factory.newSAXParser();
             if (Languages.W3C_XML_SCHEMA_NS_URI.equals(language)) {
                 parser.setProperty(Properties.SCHEMA_LANGUAGE,
@@ -159,7 +191,7 @@ public class ParsingValidator extends Validator {
      * through the {@link Handler}, only entities declared inside the
      * instance are affected.</p>
      */
-    private static void disableExternalEntities(SAXParserFactory factory) {
+    private static void restrictExternalEntities(SAXParserFactory factory) {
         setSafeFeature(factory, EXTERNAL_GENERAL_ENTITIES, false);
         setSafeFeature(factory, EXTERNAL_PARAMETER_ENTITIES, false);
     }

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/ParsingValidator.java
@@ -104,6 +104,7 @@ public class ParsingValidator extends Validator {
         try {
             factory.setNamespaceAware(true);
             factory.setValidating(true);
+            disableExternalEntities(factory);
             SAXParser parser = factory.newSAXParser();
             if (Languages.W3C_XML_SCHEMA_NS_URI.equals(language)) {
                 parser.setProperty(Properties.SCHEMA_LANGUAGE,
@@ -142,6 +143,34 @@ public class ParsingValidator extends Validator {
             throw new XMLUnitException(ex);
         } catch (java.io.IOException ex) {
             throw new XMLUnitException(ex);
+        }
+    }
+
+    private static final String EXTERNAL_GENERAL_ENTITIES =
+        "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES =
+        "http://xml.org/sax/features/external-parameter-entities";
+
+    /**
+     * Stops the instance document from pulling in external general or
+     * parameter entities while it is parsed for validation.
+     *
+     * <p>The DTD or schema to validate against is still resolved
+     * through the {@link Handler}, only entities declared inside the
+     * instance are affected.</p>
+     */
+    private static void disableExternalEntities(SAXParserFactory factory) {
+        setSafeFeature(factory, EXTERNAL_GENERAL_ENTITIES, false);
+        setSafeFeature(factory, EXTERNAL_PARAMETER_ENTITIES, false);
+    }
+
+    private static void setSafeFeature(SAXParserFactory factory, String feature, boolean value) {
+        try {
+            factory.setFeature(feature, value);
+        } catch (ParserConfigurationException ex) {
+            // feature not supported by this parser, ignore
+        } catch (SAXException ex) {
+            // feature not supported by this parser, ignore
         }
     }
 

--- a/xmlunit-core/src/main/java/org/xmlunit/validation/package-info.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/validation/package-info.java
@@ -14,5 +14,18 @@
 
 /**
  * Validation of XML documents and schemas.
+ *
+ * <p><strong>Security note:</strong> the validators in this package do
+ * not restrict access to external DTDs or entities by default. This has
+ * been a conscious decision since XMLUnit 2.6.0 because schema
+ * validation often needs to load external resources, and the package is
+ * meant to be used on trusted input. An instance document with a {@code
+ * DOCTYPE} that declares an external entity may therefore cause that
+ * entity to be resolved while it is validated, which is an XXE/SSRF
+ * vector when the input is untrusted. If you validate untrusted input
+ * use {@link org.xmlunit.validation.JAXPValidator#setDisableExternalDtdAccess
+ * JAXPValidator.setDisableExternalDtdAccess(true)} or {@link
+ * org.xmlunit.validation.ParsingValidator#setDisableExternalEntities
+ * ParsingValidator.setDisableExternalEntities(true)} to forbid this.</p>
  */
 package org.xmlunit.validation;

--- a/xmlunit-core/src/test/java/org/xmlunit/validation/ParsingValidatorTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/validation/ParsingValidatorTest.java
@@ -109,12 +109,15 @@ public class ParsingValidatorTest {
         + "<!DOCTYPE root [<!ENTITY xxe SYSTEM \"file:/no/such/xmlunit-xxe-probe\">]>"
         + "<root>&xxe;</root>";
 
-    @Test public void doesNotResolveExternalEntitiesInInstance() {
+    @Test public void doesNotResolveExternalEntitiesInInstanceWhenDisabled() {
         ParsingValidator v =
             new ParsingValidator(Languages.W3C_XML_SCHEMA_NS_URI);
+        v.setDisableExternalEntities(true);
         v.setSchemaSource(new StreamSource(new StringReader(XXE_SCHEMA)));
         ValidationResult r =
             v.validateInstance(new StreamSource(new StringReader(XXE_INSTANCE)));
+        // with the external entity left unresolved the empty element
+        // content still validates against the xsd:string element
         assertTrue(r.isValid());
     }
 

--- a/xmlunit-core/src/test/java/org/xmlunit/validation/ParsingValidatorTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/validation/ParsingValidatorTest.java
@@ -24,6 +24,7 @@ import static org.xmlunit.TestResources.TEST_RESOURCE_DIR;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -95,6 +96,26 @@ public class ParsingValidatorTest {
                                                                           + "invalidBookWithDoctype.xml")));
         assertFalse(r.isValid());
         assertTrue(r.getProblems().iterator().hasNext());
+    }
+
+    private static final String XXE_SCHEMA =
+        "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">"
+        + "<xsd:element name=\"root\" type=\"xsd:string\"/></xsd:schema>";
+
+    // the external entity points at a path that does not exist, so if
+    // it gets resolved the parser fails while trying to read it
+    private static final String XXE_INSTANCE =
+        "<?xml version=\"1.0\"?>"
+        + "<!DOCTYPE root [<!ENTITY xxe SYSTEM \"file:/no/such/xmlunit-xxe-probe\">]>"
+        + "<root>&xxe;</root>";
+
+    @Test public void doesNotResolveExternalEntitiesInInstance() {
+        ParsingValidator v =
+            new ParsingValidator(Languages.W3C_XML_SCHEMA_NS_URI);
+        v.setSchemaSource(new StreamSource(new StringReader(XXE_SCHEMA)));
+        ValidationResult r =
+            v.validateInstance(new StreamSource(new StringReader(XXE_INSTANCE)));
+        assertTrue(r.isValid());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
ParsingValidator.validateInstance parses the instance document with a validating SAX parser that resolves external entities, so a DOCTYPE in the instance can read local files or hit URLs through SYSTEM entities. The schema/DTD to validate against is resolved separately via the Handler, the instance never needs its own external entities.

Per the discussion this keeps the 2.6.0 default unchanged and adds an opt-in instead of changing behavior for everyone:

- new `setDisableExternalEntities(boolean)` on ParsingValidator, default `false` so existing behavior is unchanged
- when enabled, turns off `external-general-entities` and `external-parameter-entities` on the factory before the parser is created; DTD and schema validation are unaffected
- stronger security note in the class javadoc plus a package-level warning in `package-info.java` covering both validators
- test flips the flag on
