### PR TITLE
parse Source through hardened parser in JAXPXPathEngine

### DIFF
--- a/xmlunit-core/src/main/java/org/xmlunit/xpath/JAXPXPathEngine.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/xpath/JAXPXPathEngine.java
@@ -14,6 +14,7 @@
 package org.xmlunit.xpath;
 
 import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -22,6 +23,7 @@ import javax.xml.xpath.XPathFactory;
 import org.xmlunit.ConfigurationException;
 import org.xmlunit.XMLUnitException;
 import org.xmlunit.util.Convert;
+import org.xmlunit.util.DocumentBuilderFactoryConfigurer;
 import org.xmlunit.util.IterableNodeList;
 import org.xmlunit.util.XPathFactoryConfigurer;
 import org.w3c.dom.Node;
@@ -32,22 +34,46 @@ import org.w3c.dom.NodeList;
  */
 public class JAXPXPathEngine implements XPathEngine {
     private final XPath xpath;
+    private final DocumentBuilderFactory dbf;
 
     /**
-     * Create an XPathEngine that uses a custom XPathFactory.
-     * @param fac the factory to use
+     * Create an XPathEngine that uses a custom XPathFactory and a custom
+     * DocumentBuilderFactory for parsing {@link Source}s that are not already DOM nodes.
+     * @param fac the XPathFactory to use
+     * @param dbf the DocumentBuilderFactory to use
+     * @since XMLUnit 2.12.1
      */
-    public JAXPXPathEngine(XPathFactory fac) {
+    public JAXPXPathEngine(XPathFactory fac, DocumentBuilderFactory dbf) {
         try {
             xpath = fac.newXPath();
         } catch (Exception e) {
             throw new ConfigurationException(e);
         }
+        this.dbf = dbf;
+    }
+
+    /**
+     * Create an XPathEngine that uses a custom XPathFactory and a DocumentBuilderFactory hardened with
+     * {@link DocumentBuilderFactoryConfigurer#Default}.
+     * @param fac the factory to use
+     */
+    public JAXPXPathEngine(XPathFactory fac) {
+        this(fac, DocumentBuilderFactoryConfigurer.Default.configure(DocumentBuilderFactory.newInstance()));
     }
 
     /**
      * Create an XPathEngine that uses JAXP's default XPathFactory with {@link XPathFactoryConfigurer#Default} applied
-     * under the covers.
+     * under the covers and a custom DocumentBuilderFactory for parsing {@link Source}s that are not already DOM nodes.
+     * @param dbf the DocumentBuilderFactory to use
+     * @since XMLUnit 2.12.1
+     */
+    public JAXPXPathEngine(DocumentBuilderFactory dbf) {
+        this(XPathFactoryConfigurer.Default.configure(XPathFactory.newInstance()), dbf);
+    }
+
+    /**
+     * Create an XPathEngine that uses JAXP's default XPathFactory with {@link XPathFactoryConfigurer#Default} applied
+     * under the covers and a DocumentBuilderFactory hardened with {@link DocumentBuilderFactoryConfigurer#Default}.
      */
     public JAXPXPathEngine() {
         this(XPathFactoryConfigurer.Default.configure(XPathFactory.newInstance()));
@@ -58,7 +84,7 @@ public class JAXPXPathEngine implements XPathEngine {
      */
     @Override
     public Iterable<Node> selectNodes(String xPath, Source s) {
-        return selectNodes(xPath, Convert.toNode(s));
+        return selectNodes(xPath, Convert.toNode(s, dbf));
     }
 
     /**
@@ -66,7 +92,7 @@ public class JAXPXPathEngine implements XPathEngine {
      */
     @Override
     public String evaluate(String xPath, Source s) {
-        return evaluate(xPath, Convert.toNode(s));
+        return evaluate(xPath, Convert.toNode(s, dbf));
     }
 
     /**

--- a/xmlunit-core/src/main/java/org/xmlunit/xpath/JAXPXPathEngine.java
+++ b/xmlunit-core/src/main/java/org/xmlunit/xpath/JAXPXPathEngine.java
@@ -58,14 +58,7 @@ public class JAXPXPathEngine implements XPathEngine {
      */
     @Override
     public Iterable<Node> selectNodes(String xPath, Source s) {
-        try {
-            return new IterableNodeList(
-                (NodeList) xpath.evaluate(xPath, Convert.toInputSource(s),
-                                          XPathConstants.NODESET)
-                                        );
-        } catch (XPathExpressionException ex) {
-            throw new XMLUnitException(ex);
-        }
+        return selectNodes(xPath, Convert.toNode(s));
     }
 
     /**
@@ -73,11 +66,7 @@ public class JAXPXPathEngine implements XPathEngine {
      */
     @Override
     public String evaluate(String xPath, Source s) {
-        try {
-            return xpath.evaluate(xPath, Convert.toInputSource(s));
-        } catch (XPathExpressionException ex) {
-            throw new XMLUnitException(ex);
-        }
+        return evaluate(xPath, Convert.toNode(s));
     }
 
     /**

--- a/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
@@ -13,8 +13,8 @@
 */
 package org.xmlunit.xpath;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -52,33 +52,21 @@ public class JAXPXPathEngineTest extends AbstractXPathEngineTest {
         new JAXPXPathEngine(fac);
     }
 
-    @Test
+    @Test(expected=XMLUnitException.class)
     public void evaluateDoesNotResolveExternalEntities() throws Exception {
-        Source s = sourceWithExternalEntity();
-        try {
-            assertFalse(getEngine().evaluate("/foo", s).contains(SECRET));
-        } catch (XMLUnitException expected) {
-            // DOCTYPE rejected by the hardened parser
-        }
+        getEngine().evaluate("/foo", sourceWithExternalEntity());
     }
 
-    @Test
+    @Test(expected=XMLUnitException.class)
     public void selectNodesDoesNotResolveExternalEntities() throws Exception {
-        Source s = sourceWithExternalEntity();
-        try {
-            for (org.w3c.dom.Node n : getEngine().selectNodes("/foo", s)) {
-                assertFalse(n.getTextContent().contains(SECRET));
-            }
-        } catch (XMLUnitException expected) {
-            // DOCTYPE rejected by the hardened parser
-        }
+        getEngine().selectNodes("/foo", sourceWithExternalEntity());
     }
 
     @Test
     public void usesProvidedDocumentBuilderFactory() throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         JAXPXPathEngine engine = new JAXPXPathEngine(dbf);
-        assertTrue(engine.evaluate("/foo", sourceWithExternalEntity()).contains(SECRET));
+        assertThat(engine.evaluate("/foo", sourceWithExternalEntity()), containsString(SECRET));
     }
 
     private static final String SECRET = "TOP-SECRET-XXE-MARKER";

--- a/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
@@ -14,12 +14,14 @@
 package org.xmlunit.xpath;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.xpath.XPathFactory;
 
@@ -70,6 +72,13 @@ public class JAXPXPathEngineTest extends AbstractXPathEngineTest {
         } catch (XMLUnitException expected) {
             // DOCTYPE rejected by the hardened parser
         }
+    }
+
+    @Test
+    public void usesProvidedDocumentBuilderFactory() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        JAXPXPathEngine engine = new JAXPXPathEngine(dbf);
+        assertTrue(engine.evaluate("/foo", sourceWithExternalEntity()).contains(SECRET));
     }
 
     private static final String SECRET = "TOP-SECRET-XXE-MARKER";

--- a/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
+++ b/xmlunit-core/src/test/java/org/xmlunit/xpath/JAXPXPathEngineTest.java
@@ -13,8 +13,14 @@
 */
 package org.xmlunit.xpath;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+
+import javax.xml.transform.Source;
 import javax.xml.xpath.XPathFactory;
 
 import org.junit.Before;
@@ -22,6 +28,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xmlunit.ConfigurationException;
+import org.xmlunit.XMLUnitException;
+import org.xmlunit.builder.Input;
 
 public class JAXPXPathEngineTest extends AbstractXPathEngineTest {
     @Mock
@@ -40,5 +48,45 @@ public class JAXPXPathEngineTest extends AbstractXPathEngineTest {
     public void shouldTranslateExceptionInConstructor() throws Exception {
         when(fac.newXPath()).thenThrow(new NullPointerException());
         new JAXPXPathEngine(fac);
+    }
+
+    @Test
+    public void evaluateDoesNotResolveExternalEntities() throws Exception {
+        Source s = sourceWithExternalEntity();
+        try {
+            assertFalse(getEngine().evaluate("/foo", s).contains(SECRET));
+        } catch (XMLUnitException expected) {
+            // DOCTYPE rejected by the hardened parser
+        }
+    }
+
+    @Test
+    public void selectNodesDoesNotResolveExternalEntities() throws Exception {
+        Source s = sourceWithExternalEntity();
+        try {
+            for (org.w3c.dom.Node n : getEngine().selectNodes("/foo", s)) {
+                assertFalse(n.getTextContent().contains(SECRET));
+            }
+        } catch (XMLUnitException expected) {
+            // DOCTYPE rejected by the hardened parser
+        }
+    }
+
+    private static final String SECRET = "TOP-SECRET-XXE-MARKER";
+
+    private static Source sourceWithExternalEntity() throws Exception {
+        File secret = File.createTempFile("xmlunit-xxe", ".txt");
+        secret.deleteOnExit();
+        Writer w = new FileWriter(secret);
+        try {
+            w.write(SECRET);
+        } finally {
+            w.close();
+        }
+        String xml = "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \""
+            + secret.toURI().toASCIIString() + "\"> ]>\n"
+            + "<foo>&xxe;</foo>";
+        return Input.fromString(xml).build();
     }
 }


### PR DESCRIPTION
JAXPXPathEngine's Source-based xpath methods bypassed the secure parser:
- selectNodes(String, Source) and evaluate(String, Source) handed Convert.toInputSource(s) to javax.xml.xpath.XPath.evaluate, which parses with JAXP's own default factory, so a DOCTYPE declaring an external SYSTEM entity in the source was resolved during evaluation
- the Node-based overloads and the HasXPathMatcher/EvaluateXPathMatcher matchers already route through Convert.toNode, which uses DocumentBuilderFactoryConfigurer.Default
- both Source methods now do the same and delegate to those overloads
Added a regression test that feeds an external entity through both methods.