### PR TITLE
pin locale when parsing dates in IsDateTimePlaceholderHandler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,12 @@
 
   PRs [#333](https://github.com/xmlunit/xmlunit/pull/333)by [@jmestwa-coder](https://github.com/jmestwa-coder)
 
+* `IsDateTimePlaceholderHandler` now parses the explicit and ISO date formats using `Locale.US` rather than the JVM
+  default locale so results no longer depend on the host locale. An optional second argument allows specifying a
+  different locale as a BCP 47 language tag.
+
+  PR [#335](https://github.com/xmlunit/xmlunit/pull/335) by [@jmestwa-coder](https://github.com/jmestwa-coder)
+
 ## XMLUnit for Java 2.12.0 - /Released 2026-05-31/
 
 * bumped xmlunit-assertj3's dependency on assert to 3.27.7.

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandler.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.xmlunit.diff.ComparisonResult;
 
@@ -53,7 +54,7 @@ public class IsDateTimePlaceholderHandler implements PlaceholderHandler {
     @Override
     public ComparisonResult evaluate(final String testText, final String... args) {
         if (args != null && args.length == 1) {
-            return canParse(new SimpleDateFormat(args[0]), testText)
+            return canParse(new SimpleDateFormat(args[0], Locale.US), testText)
                 ? ComparisonResult.EQUAL
                 : ComparisonResult.DIFFERENT;
         }
@@ -71,7 +72,7 @@ public class IsDateTimePlaceholderHandler implements PlaceholderHandler {
             return true;
         }
         for (final String pattern : ISO_PATTERNS) {
-            if (canParse(new SimpleDateFormat(pattern), testText)) {
+            if (canParse(new SimpleDateFormat(pattern, Locale.US), testText)) {
                 return true;
             }
         }

--- a/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandler.java
+++ b/xmlunit-placeholders/src/main/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandler.java
@@ -51,10 +51,21 @@ public class IsDateTimePlaceholderHandler implements PlaceholderHandler {
         return PLACEHOLDER_NAME;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The first optional argument is the date/time pattern, the
+     * second optional argument is the locale used to parse it, given
+     * as a BCP 47 language tag (for example {@code de} or {@code
+     * fr-FR}). When no locale is given {@link Locale#US} is used.</p>
+     */
     @Override
     public ComparisonResult evaluate(final String testText, final String... args) {
-        if (args != null && args.length == 1) {
-            return canParse(new SimpleDateFormat(args[0], Locale.US), testText)
+        if (args != null && args.length >= 1) {
+            final Locale locale = args.length >= 2 && args[1] != null && !"".equals(args[1])
+                ? Locale.forLanguageTag(args[1])
+                : Locale.US;
+            return canParse(new SimpleDateFormat(args[0], locale), testText)
                 ? ComparisonResult.EQUAL
                 : ComparisonResult.DIFFERENT;
         }

--- a/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandlerTest.java
+++ b/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandlerTest.java
@@ -73,4 +73,16 @@ public class IsDateTimePlaceholderHandlerTest {
         assertThat(placeholderHandler.evaluate("abc", "dd MM yyyy HH:mm"),
                    equalTo(ComparisonResult.DIFFERENT));
     }
+
+    @Test
+    public void shouldParsePatternIndependentOfDefaultLocale() {
+        final Locale l = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMANY);
+            assertThat(placeholderHandler.evaluate("24 June 2023", "dd MMMM yyyy"),
+                       equalTo(ComparisonResult.EQUAL));
+        } finally {
+            Locale.setDefault(l);
+        }
+    }
 }

--- a/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandlerTest.java
+++ b/xmlunit-placeholders/src/test/java/org/xmlunit/placeholder/IsDateTimePlaceholderHandlerTest.java
@@ -85,4 +85,12 @@ public class IsDateTimePlaceholderHandlerTest {
             Locale.setDefault(l);
         }
     }
+
+    @Test
+    public void shouldParsePatternWithExplicitLocale() {
+        assertThat(placeholderHandler.evaluate("24 Juni 2023", "dd MMMM yyyy", "de"),
+                   equalTo(ComparisonResult.EQUAL));
+        assertThat(placeholderHandler.evaluate("24 Juni 2023", "dd MMMM yyyy", "en"),
+                   equalTo(ComparisonResult.DIFFERENT));
+    }
 }


### PR DESCRIPTION
**Locale-dependent date parsing in IsDateTimePlaceholderHandler**
The explicit-pattern and ISO `SimpleDateFormat` instances are built without a locale, so the untrusted value is parsed against the JVM default locale: `24 June 2023` matches `dd MMMM yyyy` on an English JVM but is rejected on a German or French one. Pinned both to `Locale.US` so the fixed formats parse the same everywhere; the locale-aware short-format fallbacks documented as "current locale" stay as is.